### PR TITLE
Fx to Map coords

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -157,6 +157,7 @@ Private Enum ServerPacketID
     CancelOfferItem
     PalabrasMagicas
     PlayAttackAnim
+    FXtoMap
 End Enum
 
 Private Enum ClientPacketID
@@ -18884,4 +18885,17 @@ Public Function PrepareMessageCharacterAttackAnim(ByVal CharIndex As Integer) As
     
     PrepareMessageCharacterAttackAnim = .ReadASCIIStringFixed(.length)
     End With
+End Function
+
+Public Function PrepareMessageFXtoMap(ByVal FxIndex As Integer, ByVal loops As Byte, ByVal x As Integer, ByVal y As Integer) As String
+    With auxiliarBuffer
+        Call .WriteByte(ServerPacketID.FXtoMap)
+        Call .WriteByte(loops)
+        Call .WriteInteger(x)
+        Call .WriteInteger(y)
+        Call .WriteInteger(FxIndex)
+        
+    PrepareMessageFXtoMap = .ReadASCIIStringFixed(.length)
+    End With
+
 End Function

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -1538,6 +1538,10 @@ Sub HechizoPropNPC(ByVal SpellIndex As Integer, ByVal NpcIndex As Integer, ByVal
 Dim daño As Long
 
 With Npclist(NpcIndex)
+    
+    Dim tempX, tempY As Integer
+    tempX = .Pos.X
+    tempY = .Pos.Y
     'Salud
     If Hechizos(SpellIndex).SubeHP = 1 Then
         
@@ -1559,6 +1563,7 @@ With Npclist(NpcIndex)
             HechizoCasteado = False
             Exit Sub
         End If
+        
         Call NPCAtacado(NpcIndex, UserIndex)
         daño = RandomNumber(Hechizos(SpellIndex).MinHp, Hechizos(SpellIndex).MaxHp)
         daño = daño + Porcentaje(daño, 3 * UserList(UserIndex).Stats.ELV)
@@ -1597,6 +1602,7 @@ With Npclist(NpcIndex)
         If .Stats.MinHp < 1 Then
             .Stats.MinHp = 0
             Call MuereNpc(NpcIndex, UserIndex)
+            Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessageFXtoMap(Hechizos(SpellIndex).FXgrh, Hechizos(SpellIndex).Loops, tempX, tempY))
         End If
     End If
 End With


### PR DESCRIPTION
When a npc is killed, the server sends to al clients in area to play the FX in the map instead of playing it on the npc.

Te protocol has the prepareMessageFXtoMap function who prepares the message to be sent. it can be used to send any Fx to be played in any map coordinates.

closes ao-libre/ao-cliente#51