### PR TITLE
Cambio la recursividad del HandleIncomingData, y ahora pasa a ser ite…

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -386,7 +386,7 @@ End Sub
 '
 ' @param    userIndex The index of the user sending the message.
 
-Public Sub HandleIncomingData(ByVal Userindex As Integer)
+Public Function HandleIncomingData(ByVal Userindex As Integer) As Boolean
 
     '***************************************************
     'Author: Juan Martin Sotuyo Dodero (Maraxus)
@@ -850,16 +850,20 @@ Public Sub HandleIncomingData(ByVal Userindex As Integer)
     'Done with this packet, move on to next one or send everything if no more packets found
     If UserList(Userindex).incomingData.Length > 0 And Err.Number = 0 Then
         Err.Clear
-        Call HandleIncomingData(Userindex)
+        HandleIncomingData = True ' Tenemos mas datos!
     
     ElseIf Err.Number <> 0 And Not Err.Number = UserList(Userindex).incomingData.NotEnoughDataErrCode Then
         'An error ocurred, log it and kick player.
         Call LogError("Error: " & Err.Number & " [" & Err.description & "] " & " Source: " & Err.source & vbTab & " HelpFile: " & Err.HelpFile & vbTab & " HelpContext: " & Err.HelpContext & vbTab & " LastDllError: " & Err.LastDllError & vbTab & " - UserIndex: " & Userindex & " - producido al manejar el paquete: " & CStr(packetID))
         Call CloseSocket(Userindex)
+
+        HandleIncomingData = False
     
     Else
         'Flush buffer - send everything that has been written
         Call FlushBuffer(Userindex)
+
+        HandleIncomingData = False
 
     End If
 

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -763,7 +763,8 @@ With UserList(MiDato)
     Call .incomingData.WriteASCIIStringFixed(Datos)
     
     If .ConnID <> -1 Then
-        Call HandleIncomingData(MiDato)
+        While HandleIncomingData(MiDato) = True ' Iteramos en todos los datos
+        Loop
     Else
         Exit Sub
     End If

--- a/Codigo/wskapiAO.bas
+++ b/Codigo/wskapiAO.bas
@@ -605,7 +605,8 @@ Public Sub EventoSockRead(ByVal Slot As Integer, ByRef Datos() As Byte)
             Call .incomingData.WriteBlock(Datos)
     
             If .ConnID <> -1 Then
-                Call HandleIncomingData(Slot)
+                While HandleIncomingData(Slot) = True ' Iteramos en todos los datos
+                Loop
             Else
                 Exit Sub
 


### PR DESCRIPTION
Este cambio arregla el siguiente **issue**: [#63](https://github.com/ao-libre/ao-server/issues/63)

Esto arreglaría los crash del programa que suceden sin mucha explicación. Un usuario podía forzar este error al enviar con un Sniffer una gran cantidad de paquetes pequeños y en el servidor realiza recursividad en la función `Sub HandleIncomingData` hasta que termina apareciendo 'Out of stack space'.

[Aquí una explicación mas detallada de lo que sucede](https://github.com/MicrosoftDocs/VBA-Docs/blob/master/Language/Reference/User-Interface-Help/out-of-stack-space-error-28.md)