### PR TITLE
Agregado limite para la recepción de paquetes.

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1527,6 +1527,8 @@ Public Type UserCounters
     
     goHome As Long
     AsignedSkills As Byte
+    
+    PacketsTick As Byte
 
 End Type
 

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -405,6 +405,7 @@ Public Sub HandleIncomingData(ByVal Userindex As Integer)
         'Si recibis 10 paquetes en 40ms (intervalo del GameTimer), cierro la conexion.
         If .Counters.PacketsTick > 10 Then
             Call CloseSocket(Userindex)
+            Exit Sub
         End If
         
         'Verifico si el paquete necesita que el user este logeado

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -394,39 +394,49 @@ Public Sub HandleIncomingData(ByVal Userindex As Integer)
     '
     '***************************************************
     On Error Resume Next
-
-    Dim packetID As Byte
     
-    packetID = UserList(Userindex).incomingData.PeekByte()
-    
-    'Does the packet requires a logged user??
-    If Not (packetID = ClientPacketID.ThrowDices Or packetID = ClientPacketID.LoginExistingChar Or packetID = ClientPacketID.LoginNewChar Or packetID = ClientPacketID.LoginNewAccount Or packetID = ClientPacketID.LoginExistingAccount) Then
+    With UserList(Userindex)
         
-        'Is the user actually logged?
-        If Not UserList(Userindex).flags.UserLogged Then
+        Dim packetID As Byte: packetID = .incomingData.PeekByte()
+        
+        'Contamos cuantos paquetes recibimos.
+        .Counters.PacketsTick = .Counters.PacketsTick + 1
+        
+        'Si recibis 10 paquetes en 40ms (intervalo del GameTimer), cierro la conexion.
+        If .Counters.PacketsTick > 10 Then
             Call CloseSocket(Userindex)
-            Exit Sub
+        End If
         
-            'He is logged. Reset idle counter if id is valid.
+        'Verifico si el paquete necesita que el user este logeado
+        If Not (packetID = ClientPacketID.ThrowDices Or packetID = ClientPacketID.LoginExistingChar Or packetID = ClientPacketID.LoginNewChar Or packetID = ClientPacketID.LoginNewAccount Or packetID = ClientPacketID.LoginExistingAccount) Then
+            
+            'Vierifico si el user esta logeado
+            If Not .flags.UserLogged Then
+                Call CloseSocket(Userindex)
+                Exit Sub
+            
+                'El usuario ya logueo. Reseteamos el tiempo AFK si el ID es valido.
+            ElseIf packetID <= LAST_CLIENT_PACKET_ID Then
+                .Counters.IdleCount = 0
+    
+            End If
+    
         ElseIf packetID <= LAST_CLIENT_PACKET_ID Then
-            UserList(Userindex).Counters.IdleCount = 0
-
-        End If
-
-    ElseIf packetID <= LAST_CLIENT_PACKET_ID Then
-        UserList(Userindex).Counters.IdleCount = 0
-        
-        'Is the user logged?
-        If UserList(Userindex).flags.UserLogged Then
-            Call CloseSocket(Userindex)
-            Exit Sub
-
-        End If
-
-    End If
+            .Counters.IdleCount = 0
+            
+            'Vierifico si el user esta logeado
+            If .flags.UserLogged Then
+                Call CloseSocket(Userindex)
+                Exit Sub
     
-    ' Ante cualquier paquete, pierde la proteccion de ser atacado.
-    UserList(Userindex).flags.NoPuedeSerAtacado = False
+            End If
+    
+        End If
+        
+        ' Ante cualquier paquete, pierde la proteccion de ser atacado.
+        .flags.NoPuedeSerAtacado = False
+        
+    End With
     
     Select Case packetID
 

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -397,8 +397,6 @@ Public Sub HandleIncomingData(ByVal Userindex As Integer)
     
     With UserList(Userindex)
         
-        Dim packetID As Byte: packetID = .incomingData.PeekByte()
-        
         'Contamos cuantos paquetes recibimos.
         .Counters.PacketsTick = .Counters.PacketsTick + 1
         
@@ -408,6 +406,8 @@ Public Sub HandleIncomingData(ByVal Userindex As Integer)
             Exit Sub
         End If
         
+        Dim packetID As Byte: packetID = .incomingData.PeekByte()
+
         'Verifico si el paquete necesita que el user este logeado
         If Not (packetID = ClientPacketID.ThrowDices Or packetID = ClientPacketID.LoginExistingChar Or packetID = ClientPacketID.LoginNewChar Or packetID = ClientPacketID.LoginNewAccount Or packetID = ClientPacketID.LoginExistingAccount) Then
             

--- a/Codigo/mMainLoop.bas
+++ b/Codigo/mMainLoop.bas
@@ -383,9 +383,12 @@ Private Sub GameTimer()
 
                 End If 'UserLogged
                 
-                'If there is anything to be sent, we send it
+                'Si quedo algo para mandar, lo mandamos.
                 Call FlushBuffer(iUserIndex)
-
+                
+                'Ya terminamos de procesar el paquete, sigamos recibiendo.
+                .Counters.PacketsTick = 0
+                
             End If
 
         End With


### PR DESCRIPTION
Esto es un enfoque diferente a lo que estaba tratando de hacer @MateoMiccino en #125 

En este PR, seguimos usando la recursividad pero establecemos un límite de paquetes que se pueden enviar de hasta 10 paquetes en 40ms.

Créditos a @Juanmz por este aporte.