### PR TITLE
No se caen los items y el oro al morir en Zona Segura.

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1984,20 +1984,23 @@ Sub TirarTodo(ByVal Userindex As Integer)
 
     With UserList(Userindex)
 
-        If MapData(.Pos.Map, .Pos.x, .Pos.Y).trigger = 6 Then Exit Sub
+        If MapData(.Pos.Map, .Pos.X, .Pos.Y).trigger = 6 Then Exit Sub
         
-        Call TirarTodosLosItems(Userindex)
-        
-        Dim Cantidad As Long: Cantidad = .Stats.Gld - CLng(.Stats.ELV) * 10000
-       
-        ' Si estas en zona segura tampoco se tira el oro.
-        If MapInfo(.Pos.Map).Pk Then
+        ' Si estas en zona segura no tiramos nada.
+        If MapInfo(.Pos.Map).Pk Then Exit Sub
             
-            If Cantidad > 0 Then
-                Call TirarOro(Cantidad, Userindex)
-            End If
-            
+        ' << Si es newbie no pierde el inventario >>
+        If Not EsNewbie(Userindex) Then
+            Call TirarTodosLosItems(Userindex)
+        Else
+            Call TirarTodosLosItemsNoNewbies(Userindex)
+    
         End If
+            
+        Dim Cantidad As Long: Cantidad = .Stats.Gld - CLng(.Stats.ELV) * 10000
+               
+        ' Tiramos el oro.
+        If Cantidad > 0 Then Call TirarOro(Cantidad, Userindex)
         
     End With
 

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1988,12 +1988,17 @@ Sub TirarTodo(ByVal Userindex As Integer)
         
         Call TirarTodosLosItems(Userindex)
         
-        Dim Cantidad As Long
-
-        Cantidad = .Stats.Gld - CLng(.Stats.ELV) * 10000
+        Dim Cantidad As Long: Cantidad = .Stats.Gld - CLng(.Stats.ELV) * 10000
+       
+        ' Si estas en zona segura tampoco se tira el oro.
+        If MapInfo(.Pos.Map).Pk Then
+            
+            If Cantidad > 0 Then
+                Call TirarOro(Cantidad, Userindex)
+            End If
+            
+        End If
         
-        If Cantidad > 0 Then Call TirarOro(Cantidad, Userindex)
-
     End With
 
     Exit Sub

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1984,23 +1984,20 @@ Sub TirarTodo(ByVal Userindex As Integer)
 
     With UserList(Userindex)
 
-        If MapData(.Pos.Map, .Pos.X, .Pos.Y).trigger = 6 Then Exit Sub
+        If MapData(.Pos.Map, .Pos.x, .Pos.Y).trigger = 6 Then Exit Sub
         
-        ' Si estas en zona segura no tiramos nada.
-        If MapInfo(.Pos.Map).Pk Then Exit Sub
-            
-        ' << Si es newbie no pierde el inventario >>
-        If Not EsNewbie(Userindex) Then
-            Call TirarTodosLosItems(Userindex)
-        Else
-            Call TirarTodosLosItemsNoNewbies(Userindex)
-    
-        End If
-            
+        Call TirarTodosLosItems(Userindex)
+        
         Dim Cantidad As Long: Cantidad = .Stats.Gld - CLng(.Stats.ELV) * 10000
-               
-        ' Tiramos el oro.
-        If Cantidad > 0 Then Call TirarOro(Cantidad, Userindex)
+       
+        ' Si estas en zona segura tampoco se tira el oro.
+        If MapInfo(.Pos.Map).Pk Then
+            
+            If Cantidad > 0 Then
+                Call TirarOro(Cantidad, Userindex)
+            End If
+            
+        End If
         
     End With
 

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1740,13 +1740,18 @@ Public Sub UserDie(ByVal Userindex As Integer)
         If TriggerZonaPelea(Userindex, Userindex) <> eTrigger6.TRIGGER6_PERMITE Then
 
             If DropItemsAlMorir Then
-
-                ' << Si es newbie no pierde el inventario >>
-                If Not EsNewbie(Userindex) Then
-                    Call TirarTodo(Userindex)
-                Else
-                    Call TirarTodosLosItemsNoNewbies(Userindex)
-
+                
+                ' Si estas en zona segura no se caen los items.
+                If MapInfo(.Pos.Map).Pk Then
+                
+                    ' << Si es newbie no pierde el inventario >>
+                    If Not EsNewbie(Userindex) Then
+                        Call TirarTodo(Userindex)
+                    Else
+                        Call TirarTodosLosItemsNoNewbies(Userindex)
+    
+                    End If
+                    
                 End If
 
             End If

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1738,9 +1738,23 @@ Public Sub UserDie(ByVal Userindex As Integer)
         End If
         
         If TriggerZonaPelea(Userindex, Userindex) <> eTrigger6.TRIGGER6_PERMITE Then
-            
-            ' Tiramos los items y el oro.
-            If DropItemsAlMorir Then Call TirarTodo(Userindex)
+
+            If DropItemsAlMorir Then
+                
+                ' Si estas en zona segura no se caen los items.
+                If MapInfo(.Pos.Map).Pk Then
+                
+                    ' << Si es newbie no pierde el inventario >>
+                    If Not EsNewbie(Userindex) Then
+                        Call TirarTodo(Userindex)
+                    Else
+                        Call TirarTodosLosItemsNoNewbies(Userindex)
+    
+                    End If
+                    
+                End If
+
+            End If
 
         End If
         

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1738,23 +1738,9 @@ Public Sub UserDie(ByVal Userindex As Integer)
         End If
         
         If TriggerZonaPelea(Userindex, Userindex) <> eTrigger6.TRIGGER6_PERMITE Then
-
-            If DropItemsAlMorir Then
-                
-                ' Si estas en zona segura no se caen los items.
-                If MapInfo(.Pos.Map).Pk Then
-                
-                    ' << Si es newbie no pierde el inventario >>
-                    If Not EsNewbie(Userindex) Then
-                        Call TirarTodo(Userindex)
-                    Else
-                        Call TirarTodosLosItemsNoNewbies(Userindex)
-    
-                    End If
-                    
-                End If
-
-            End If
+            
+            ' Tiramos los items y el oro.
+            If DropItemsAlMorir Then Call TirarTodo(Userindex)
 
         End If
         

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -321,7 +321,7 @@ End Enum
 
 ''
 'The last existing client packet id.
-Private Const LAST_CLIENT_PACKET_ID As Byte = 139
+Private Const LAST_CLIENT_PACKET_ID As Byte = 144
 
 Public Enum FontTypeNames
 


### PR DESCRIPTION
En teoría no podes morir en zona segura, pero si por ejemplo, llegas a zona segura y morís por envenenamiento se te caen todos los items.