### PR TITLE
Disable the API connection by default.

### DIFF
--- a/Server.ini
+++ b/Server.ini
@@ -152,7 +152,7 @@ X=45
 Y=88
 
 [CONEXIONAPI]
-Activado=1
+Activado=0
 UrlServer=http://localhost:1337
 
 [DATABASE]


### PR DESCRIPTION
Se ha detectado un error que al crear una cuenta SIN antes haber instalado y configurado la API de Node.js provocará el siguiente error:

```20/05/2019 07:54:40 p.m. Error: -2146697211 [Error de Automatización]  Source: AOLibreServer	 HelpFile: 	 HelpContext: 1000440	 LastDllError: 0	 - UserIndex: 1 - producido al manejar el paquete: 131```