### PR TITLE
To avoid write a false error in the logs, if the err.number in the handleCreateItem is 0 we don't write it in the log

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -14568,7 +14568,9 @@ Private Sub HandleCreateItem(ByVal Userindex As Integer)
     End With
     
 ErrHandler:
-    Call LogError("Error en HandleCreateItem " & Err.Number & " " & Err.description)
+    If Err.Number <> 0 Then
+        Call LogError("Error en HandleCreateItem " & Err.Number & " " & Err.description)
+    End If
 End Sub
 
 ''


### PR DESCRIPTION
To avoid write a false error in the logs, if the err.number in the handleCreateItem is 0 we don't write it in the log