### PR TITLE
Uso Long en la variable packetID del HandleIncomingData()

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -421,7 +421,6 @@ Public Function HandleIncomingData(ByVal Userindex As Integer) As Boolean
         Dim packetID As Long: packetID = CLng(.incomingData.PeekByte())
 
         'Verifico si el paquete necesita que el user este logeado
-        'TODO: BORRAR packetID = ClientPacketID.LoginExistingChar por que no se usa mas, borrarlo aca y en el cliente
         If Not (packetID = ClientPacketID.ThrowDices _
                 Or packetID = ClientPacketID.LoginExistingChar _
                 Or packetID = ClientPacketID.LoginNewChar _

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -418,7 +418,7 @@ Public Function HandleIncomingData(ByVal Userindex As Integer) As Boolean
 
         'End If
         
-        Dim packetID As Byte: packetID = .incomingData.PeekByte()
+        Dim packetID As Long: packetID = CLng(.incomingData.PeekByte())
 
         'Verifico si el paquete necesita que el user este logeado
         'TODO: BORRAR packetID = ClientPacketID.LoginExistingChar por que no se usa mas, borrarlo aca y en el cliente


### PR DESCRIPTION
Según [este aporte](https://www.gs-zone.org/temas/las-consecuencias-de-usar-byte-en-handleincomingdata.99245) de Wolftein, hay un bug en el compilador de VB6 que hace que no se generen bien las tablas de salto en los bloques Switch, esto se arregla usando Integer o Long en este tipo de expresiones.