### PR TITLE
bugfix: podian equipar la montura mientras estaba el conteo de salida

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -2445,11 +2445,6 @@ Sub Cerrar_Usuario(ByVal Userindex As Integer)
                 .Counters.goHome = 0
 
             End If
-
-            ' Si esta equitando, lo bajamos de la montura
-            If .flags.Equitando = 1 Then
-                Call UnmountMontura(Userindex)
-            End If
             
             Call WriteConsoleMsg(Userindex, "Cerrando...Se cerrara el juego en " & .Counters.Salir & " segundos...", FontTypeNames.FONTTYPE_INFO)
 

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -6081,14 +6081,6 @@ Private Sub HandleQuit(ByVal Userindex As Integer)
         'Remove packet ID
         Call .incomingData.ReadByte
 
-        'Se hace esta validacion para prevenir errores saliendo con personajes con monturas y entrando con otros sin. 
-        'Por lo que todos los pjs cuando salen del juego deberan estar fuera de su montura. (Recox)
-        If .flags.Equitando = 1 Then
-            Call WriteConsoleMsg(Userindex, "No puedes salir estando en tu montura!!", FontTypeNames.FONTTYPE_WARNING)
-            Exit Sub
-        End If
-        
-        
         If .flags.Paralizado = 1 Then
             Call WriteConsoleMsg(Userindex, "No puedes salir estando paralizado.", FontTypeNames.FONTTYPE_WARNING)
             Exit Sub

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -1076,9 +1076,15 @@ End Sub
 
             End If
             
-            ' Retos nVSn. Usuario cierra conexi�n.
+            ' Retos nVSn. Usuario cierra conexion.
             If .flags.SlotReto > 0 Then
                 Call Retos.UserdieFight(Userindex, 0, True)
+            End If
+
+            ' Desequipamos la montura justo antes de cerrar el socket
+            ' para prevenir que se la equipe durante el conteo de salida (WyroX)
+            If .flags.Equitando = 1 Then
+                Call UnmountMontura(Userindex)
             End If
             
             'Empty buffer for reuse


### PR DESCRIPTION
Pasos para reproducir el bug:
- Escribir /salir en algún lugar inseguro para que tarde 10 segundos
- Equipar la montura en ese tiempo

Solución:
- Hacer un único chequeo en CloseSocket, justo antes de cerrar al usuario
- Bajarlo de la montura si es necesario