### PR TITLE
Fix spam al comprar objetos (reducidos los paquetes)

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -50,13 +50,13 @@ Private Const SEPARATOR As String * 1 = vbNullChar
 Private auxiliarBuffer  As clsByteQueue
 
 Private Enum ServerPacketID
-    logged = 1                  ' LOGGED
+    Logged = 1                  ' LOGGED
     RemoveDialogs = 2           ' QTDL
     RemoveCharDialog = 3       ' QDL
     NavigateToggle = 4         ' NAVEG
     Disconnect = 5              ' FINOK
     CommerceEnd = 6            ' FINCOMOK
-    BankEnd  = 7               ' FINBANOK
+    BankEnd = 7                ' FINBANOK
     CommerceInit = 8            ' INITCOM
     BankInit = 9                ' INITBANCO
     UserCommerceInit = 10        ' INITCOMUSU
@@ -88,7 +88,7 @@ Private Enum ServerPacketID
     ObjectDelete = 36           ' BO
     BlockPosition = 37        ' BQ
     PlayMp3 = 38
-    PlayMIDI = 39               ' TM
+    PlayMidi = 39               ' TM
     PlayWave = 40               ' TW
     guildList = 41              ' GL
     AreaChanged = 42           ' CA
@@ -104,7 +104,7 @@ Private Enum ServerPacketID
     BlacksmithArmors = 52       ' LAR
     InitCarpenting = 53         ' OBR
     RestOK = 54                 ' DOK
-    ErrorMsg = 55               ' ERR
+    errorMsg = 55               ' ERR
     Blind = 56                  ' CEGU
     Dumb = 57                   ' DUMB
     ShowSignal = 58              ' MCAR
@@ -133,45 +133,43 @@ Private Enum ServerPacketID
     ShowGuildFundationForm = 81 ' SHOWFUN
     ParalizeOK = 82             ' PARADOK
     ShowUserRequest = 83        ' PETICIO
-    TradeOK = 84                ' TRANSOK
-    BankOK = 85                 ' BANCOOK
-    ChangeUserTradeSlot = 86    ' COMUSUINV
-    SendNight = 87              ' NOC
-    Pong = 88
-    UpdateTagAndStatus = 89
+    ChangeUserTradeSlot = 84    ' COMUSUINV
+    SendNight = 85              ' NOC
+    Pong = 86
+    UpdateTagAndStatus = 87
 
     'GM messages
-    SpawnList = 90               ' SPL
-    ShowSOSForm = 91            ' MSOS
-    ShowMOTDEditionForm = 92     ' ZMOTD
-    ShowGMPanelForm = 93        ' ABPANEL
-    UserNameList = 94           ' LISTUSU
-    ShowDenounces = 95
-    RecordList = 96
-    RecordDetails = 97
+    SpawnList = 88               ' SPL
+    ShowSOSForm = 89            ' MSOS
+    ShowMOTDEditionForm = 90     ' ZMOTD
+    ShowGMPanelForm = 91        ' ABPANEL
+    UserNameList = 92           ' LISTUSU
+    ShowDenounces = 93
+    RecordList = 94
+    RecordDetails = 95
     
-    ShowGuildAlign = 98
-    ShowPartyForm = 99
-    UpdateStrenghtAndDexterity = 100
-    UpdateStrenght = 101
-    UpdateDexterity = 102
-    AddSlots = 103
-    MultiMessage = 104
-    StopWorking = 105
-    CancelOfferItem = 106
-    PalabrasMagicas = 107
-    PlayAttackAnim = 108
-    FXtoMap = 109
-    AccountLogged = 110
-    SearchList = 111
-    QuestDetails = 112
-    QuestListSend = 113
-    CreateDamage = 114
-    UserInEvent = 115
-    renderMsg = 116
-    DeletedChar = 117
-    EquitandoToggle = 118
-    EnviarDatosServer = 119
+    ShowGuildAlign = 96
+    ShowPartyForm = 97
+    UpdateStrenghtAndDexterity = 98
+    UpdateStrenght = 99
+    UpdateDexterity = 100
+    AddSlots = 101
+    MultiMessage = 102
+    StopWorking = 103
+    CancelOfferItem = 104
+    PalabrasMagicas = 105
+    PlayAttackAnim = 106
+    FXtoMap = 107
+    AccountLogged = 108
+    SearchList = 109
+    QuestDetails = 110
+    QuestListSend = 111
+    CreateDamage = 112
+    UserInEvent = 113
+    RenderMsg = 114
+    DeletedChar = 115
+    EquitandoToggle = 116
+    EnviarDatosServer = 117
 End Enum
 
 Private Enum ClientPacketID

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -133,8 +133,6 @@ Private Enum ServerPacketID
     ShowGuildFundationForm  ' SHOWFUN
     ParalizeOK              ' PARADOK
     ShowUserRequest         ' PETICIO
-    TradeOK                 ' TRANSOK
-    BankOK                  ' BANCOOK
     ChangeUserTradeSlot     ' COMUSUINV
     SendNight               ' NOC
     Pong
@@ -20994,62 +20992,6 @@ Public Sub WriteShowUserRequest(ByVal Userindex As Integer, ByVal details As Str
 
     End With
 
-    Exit Sub
-
-ErrHandler:
-
-    If Err.Number = UserList(Userindex).outgoingData.NotEnoughSpaceErrCode Then
-        Call FlushBuffer(Userindex)
-        Resume
-
-    End If
-
-End Sub
-
-''
-' Writes the "TradeOK" message to the given user's outgoing data buffer.
-'
-' @param    UserIndex User to which the message is intended.
-' @remarks  The data is not actually sent until the buffer is properly flushed.
-
-Public Sub WriteTradeOK(ByVal Userindex As Integer)
-
-    '***************************************************
-    'Author: Juan Martin Sotuyo Dodero (Maraxus)
-    'Last Modification: 05/17/06
-    'Writes the "TradeOK" message to the given user's outgoing data buffer
-    '***************************************************
-    On Error GoTo ErrHandler
-
-    Call UserList(Userindex).outgoingData.WriteByte(ServerPacketID.TradeOK)
-    Exit Sub
-
-ErrHandler:
-
-    If Err.Number = UserList(Userindex).outgoingData.NotEnoughSpaceErrCode Then
-        Call FlushBuffer(Userindex)
-        Resume
-
-    End If
-
-End Sub
-
-''
-' Writes the "BankOK" message to the given user's outgoing data buffer.
-'
-' @param    UserIndex User to which the message is intended.
-' @remarks  The data is not actually sent until the buffer is properly flushed.
-
-Public Sub WriteBankOK(ByVal Userindex As Integer)
-
-    '***************************************************
-    'Author: Juan Martin Sotuyo Dodero (Maraxus)
-    'Last Modification: 05/17/06
-    'Writes the "BankOK" message to the given user's outgoing data buffer
-    '***************************************************
-    On Error GoTo ErrHandler
-
-    Call UserList(Userindex).outgoingData.WriteByte(ServerPacketID.BankOK)
     Exit Sub
 
 ErrHandler:


### PR DESCRIPTION
Reducidos la cantidad de paquetes que se envían por cada compra, venta o intercambio de items con la bóveda. Pasó de alrededor de 1kb por clic a sólo 74 bytes.

PD: No deja mergear automáticamente, seguro por los paquetes que borré del ServerPacketID