### PR TITLE
Fix - Sockets se quedan abiertos.

### DIFF
--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1745,6 +1745,7 @@ Sub LoadSini()
     
     'Misc
     Puerto = val(Lector.GetValue("INIT", "StartPort"))
+    LastSockListen = val(Lector.GetValue("INIT", "LastSockListen"))
     HideMe = CBool(Lector.GetValue("INIT", "Hide"))
     AllowMultiLogins = CBool(val(Lector.GetValue("INIT", "AllowMultiLogins")))
     IdleLimit = val(Lector.GetValue("INIT", "IdleLimit"))

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -628,8 +628,19 @@ Private Sub SocketConfig()
     
     #If UsarQueSocket = 1 Then
     
+        If LastSockListen >= 0 Then
+            Call apiclosesocket(LastSockListen) 'Cierra el socket de escucha
+        End If
+
         Call IniciaWsApi(frmMain.hWnd)
-        SockListen = ListenForConnect(Puerto, hWndMsg, "")
+        SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
+
+        If SockListen <> -1 Then
+            ' Guarda el socket escuchando
+            Call WriteVar(IniPath & "Server.ini", "INIT", "LastSockListen", SockListen)
+        Else
+            Call MsgBox("Ha ocurrido un error al iniciar el socket del Servidor.", vbCritical + vbOKOnly)
+        End If
     
     #ElseIf UsarQueSocket = 0 Then
     

--- a/Codigo/wskapiAO.bas
+++ b/Codigo/wskapiAO.bas
@@ -109,7 +109,8 @@ Option Explicit
     ' ====================================================================================
     ' ====================================================================================
 
-    Public SockListen    As Long
+    Public SockListen       As Long
+    Public LastSockListen   As Long
 
 #End If
 
@@ -680,7 +681,7 @@ Public Sub WSApiReiniciarSockets()
         Call LimpiaWsApi
         Call Sleep(100)
         Call IniciaWsApi(frmMain.hWnd)
-        SockListen = ListenForConnect(Puerto, hWndMsg, "")
+        SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
     #End If
 

--- a/Server.ini
+++ b/Server.ini
@@ -1,5 +1,6 @@
 [INIT]
 StartPort=7666
+LastSockListen=-1
 Hide=0
 AllowMultiLogins=1
 IdleLimit=5


### PR DESCRIPTION
Ahora al cerrar el servidor se guarda en el Server.ini el ID del ULTIMO socket usado para que al volver a abrir el servidor primero se cierre dicho socket y reabrirlo.

Fuente: https://www.gs-zone.org/temas/ejecutar-detener-el-servidor-infinitas-veces-en-vb6-sin-que-se-bugueen-los-sockets.74824/