### PR TITLE
MinLevel, MinSkill, anillos anti-efectos, hechizos por clase

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -744,7 +744,7 @@ Public Enum eOBJType
 
     otUseOnce = 1
     otWeapon = 2
-    otarmadura = 3
+    otArmadura = 3
     otArboles = 4
     otOro = 5
     otPuertas = 6
@@ -757,8 +757,8 @@ Public Enum eOBJType
     otBebidas = 13
     otLena = 14
     otFogata = 15
-    otescudo = 16
-    otcasco = 17
+    otEscudo = 16
+    otCasco = 17
     otAnillo = 18
     otTeleport = 19
     otMuebles = 20
@@ -1053,7 +1053,6 @@ Public Type ObjData
     MaxModificador As Integer
     MinModificador As Integer
     DuracionEfecto As Long
-    MinSkill As Integer
     LingoteIndex As Integer
     
     MinHIT As Integer 'Minimo golpe
@@ -1113,7 +1112,10 @@ Public Type ObjData
     SkCarpinteria As Integer
     
     ItemCrafteo() As CraftingItem
-    
+
+    MinSkill As Byte
+    MinLevel As Byte
+
     texto As String
     
     'Clases que no tienen permitido usar este obj
@@ -1134,6 +1136,10 @@ Public Type ObjData
     DefensaMagicaMin As Integer
     Refuerzo As Byte
     
+    ImpideParalizar As Boolean
+    ImpideAturdir As Boolean
+    ImpideCegar As Boolean
+
     Log As Byte 'es un objeto que queremos loguear? Pablo (ToxicWaste) 07/09/07
     NoLog As Byte 'es un objeto que esta prohibido loguear?
     

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -907,8 +907,9 @@ End Sub
 Sub LoadOBJData()
     '***************************************************
     'Author: Unknown
-    'Last Modification: -
-    '
+    'Last Modification: 03/02/2020
+    '03/02/2020: WyroX - Agrego nivel y skill minimo a
+    'ciertos objetos. Nuevas habilidades para anillos
     '***************************************************
 
     '###################################################
@@ -975,15 +976,17 @@ Sub LoadOBJData()
             
             Select Case .OBJType
 
-                Case eOBJType.otarmadura
+                Case eOBJType.otArmadura
                     .Real = val(Leer.GetValue("OBJ" & Object, "Real"))
                     .Caos = val(Leer.GetValue("OBJ" & Object, "Caos"))
                     .LingH = val(Leer.GetValue("OBJ" & Object, "LingH"))
                     .LingP = val(Leer.GetValue("OBJ" & Object, "LingP"))
                     .LingO = val(Leer.GetValue("OBJ" & Object, "LingO"))
                     .SkHerreria = val(Leer.GetValue("OBJ" & Object, "SkHerreria"))
+                    .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                 
-                Case eOBJType.otescudo
+                Case eOBJType.otEscudo
                     .ShieldAnim = val(Leer.GetValue("OBJ" & Object, "Anim"))
                     .LingH = val(Leer.GetValue("OBJ" & Object, "LingH"))
                     .LingP = val(Leer.GetValue("OBJ" & Object, "LingP"))
@@ -991,8 +994,10 @@ Sub LoadOBJData()
                     .SkHerreria = val(Leer.GetValue("OBJ" & Object, "SkHerreria"))
                     .Real = val(Leer.GetValue("OBJ" & Object, "Real"))
                     .Caos = val(Leer.GetValue("OBJ" & Object, "Caos"))
+                    .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                 
-                Case eOBJType.otcasco
+                Case eOBJType.otCasco
                     .CascoAnim = val(Leer.GetValue("OBJ" & Object, "Anim"))
                     .LingH = val(Leer.GetValue("OBJ" & Object, "LingH"))
                     .LingP = val(Leer.GetValue("OBJ" & Object, "LingP"))
@@ -1000,6 +1005,8 @@ Sub LoadOBJData()
                     .SkHerreria = val(Leer.GetValue("OBJ" & Object, "SkHerreria"))
                     .Real = val(Leer.GetValue("OBJ" & Object, "Real"))
                     .Caos = val(Leer.GetValue("OBJ" & Object, "Caos"))
+                    .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                 
                 Case eOBJType.otWeapon
                     .WeaponAnim = val(Leer.GetValue("OBJ" & Object, "Anim"))
@@ -1021,6 +1028,8 @@ Sub LoadOBJData()
                     .Caos = val(Leer.GetValue("OBJ" & Object, "Caos"))
                     
                     .WeaponRazaEnanaAnim = val(Leer.GetValue("OBJ" & Object, "RazaEnanaAnim"))
+                    .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                 
                 Case eOBJType.otInstrumentos
                     .Snd1 = val(Leer.GetValue("OBJ" & Object, "SND1"))
@@ -1046,17 +1055,22 @@ Sub LoadOBJData()
                 
                 Case eOBJType.otBarcos
                     .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                     .MaxHIT = val(Leer.GetValue("OBJ" & Object, "MaxHIT"))
                     .MinHIT = val(Leer.GetValue("OBJ" & Object, "MinHIT"))
+                    .Real = val(Leer.GetValue("OBJ" & Object, "Real"))
+                    .Caos = val(Leer.GetValue("OBJ" & Object, "Caos"))
                 
                 Case eOBJType.otFlechas
                     .MaxHIT = val(Leer.GetValue("OBJ" & Object, "MaxHIT"))
                     .MinHIT = val(Leer.GetValue("OBJ" & Object, "MinHIT"))
                     .Envenena = val(Leer.GetValue("OBJ" & Object, "Envenena"))
                     .Paraliza = val(Leer.GetValue("OBJ" & Object, "Paraliza"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
 
                 Case eOBJType.otMonturas
                     .MinSkill = val(Leer.GetValue("OBJ" & Object, "MinSkill"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                     .MaxHIT = val(Leer.GetValue("OBJ" & Object, "MaxHIT"))
                     .MinHIT = val(Leer.GetValue("OBJ" & Object, "MinHIT"))
 
@@ -1067,16 +1081,26 @@ Sub LoadOBJData()
                     .SkHerreria = val(Leer.GetValue("OBJ" & Object, "SkHerreria"))
                     .MaxHIT = val(Leer.GetValue("OBJ" & Object, "MaxHIT"))
                     .MinHIT = val(Leer.GetValue("OBJ" & Object, "MinHIT"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
+                    '(WyroX)
+                    .ImpideParalizar = val(Leer.GetValue("OBJ" & Object, "ImpideParalizar")) <> 0
+                    .ImpideAturdir = val(Leer.GetValue("OBJ" & Object, "ImpideAturdir")) <> 0
+                    .ImpideCegar = val(Leer.GetValue("OBJ" & Object, "ImpideCegar")) <> 0
+                    '(/WyroX)
                     
                 Case eOBJType.otTeleport
                     .Radio = val(Leer.GetValue("OBJ" & Object, "Radio"))
                     
                 Case eOBJType.otMochilas
                     .MochilaType = val(Leer.GetValue("OBJ" & Object, "MochilaType"))
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
                     
                 Case eOBJType.otForos
                     Call AddForum(Leer.GetValue("OBJ" & Object, "ID"))
                     
+                Case eOBJType.otPergaminos
+                    .MinLevel = val(Leer.GetValue("OBJ" & Object, "MinLevel"))
+
             End Select
             
             .Ropaje = val(Leer.GetValue("OBJ" & Object, "NumRopaje"))
@@ -1170,7 +1194,7 @@ Sub LoadOBJData()
             Else
                 Erase .ItemCrafteo
             End If
-            
+
             'Bebidas
             .MinSta = val(Leer.GetValue("OBJ" & Object, "MinST"))
             

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -832,7 +832,7 @@ Public Sub Desequipar(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End With
             
-            Case eOBJType.otarmadura
+            Case eOBJType.otArmadura
 
                 With .Invent
                     .Object(Slot).Equipped = 0
@@ -848,7 +848,7 @@ Public Sub Desequipar(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End With
                  
-            Case eOBJType.otcasco
+            Case eOBJType.otCasco
 
                 With .Invent
                     .Object(Slot).Equipped = 0
@@ -867,7 +867,7 @@ Public Sub Desequipar(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End If
             
-            Case eOBJType.otescudo
+            Case eOBJType.otEscudo
 
                 With .Invent
                     .Object(Slot).Equipped = 0
@@ -1010,9 +1010,10 @@ End Function
 Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
     '*************************************************
     'Author: Unknown
-    'Last modified: 14/01/2010 (ZaMa)
+    'Last modified: 03/02/2020
     '01/08/2009: ZaMa - Now it's not sent any sound made by an invisible admin
     '14/01/2010: ZaMa - Agrego el motivo especifico por el que no puede equipar/usar el item.
+    '03/02/2020: WyroX - Nivel minimo y skill minimo para poder equipar
     '*************************************************
 
     On Error GoTo ErrHandler
@@ -1036,12 +1037,24 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
             Exit Sub
 
         End If
+
+        ' Nivel minimo
+        If .Stats.ELV < obj.MinLevel Then
+            Call WriteConsoleMsg(UserIndex, "Necesitas ser nivel " & obj.MinLevel & " para poder equipar este objeto.", FontTypeNames.FONTTYPE_INFO)
+            Exit Sub
+        End If
                 
         Select Case obj.OBJType
 
             Case eOBJType.otWeapon
 
                 If ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) And FaccionPuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
+
+                    'Check skill
+                    If .Stats.UserSkills(eSkill.Armas) < obj.MinSkill Then
+                        Call WriteConsoleMsg(UserIndex, "Necesitas " & obj.MinSkill & " puntos en Combate con armas para poder equipar este objeto.", FontTypeNames.FONTTYPE_INFO)
+                        Exit Sub
+                    End If
 
                     'Si esta equipado lo quita
                     If .Invent.Object(Slot).Equipped Then
@@ -1141,7 +1154,7 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End If
             
-            Case eOBJType.otarmadura
+            Case eOBJType.otArmadura
 
                 If .flags.Navegando = 1 Then
                     Call WriteConsoleMsg(UserIndex, "No podes equiparte o desequiparte vestimentas o armaduras mientras estas navegando.", FontTypeNames.FONTTYPE_INFO)
@@ -1156,7 +1169,13 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
                 
                 'Nos aseguramos que puede usarla
                 If ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) And SexoPuedeUsarItem(UserIndex, ObjIndex, sMotivo) And CheckRazaUsaRopa(UserIndex, ObjIndex, sMotivo) And FaccionPuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
-                   
+
+                    'Check skill
+                    If .Stats.UserSkills(eSkill.Tacticas) < obj.MinSkill Then
+                        Call WriteConsoleMsg(UserIndex, "Necesitas " & obj.MinSkill & " puntos en Evasion en combate para poder equipar este objeto.", FontTypeNames.FONTTYPE_INFO)
+                        Exit Sub
+                    End If
+
                     'Si esta equipado lo quita
                     If .Invent.Object(Slot).Equipped Then
                         Call Desequipar(UserIndex, Slot)
@@ -1196,10 +1215,16 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End If
             
-            Case eOBJType.otcasco
+            Case eOBJType.otCasco
 
                 If .flags.Navegando = 1 Then Exit Sub
                 If ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
+
+                    'Check skill
+                    If .Stats.UserSkills(eSkill.Tacticas) < obj.MinSkill Then
+                        Call WriteConsoleMsg(UserIndex, "Necesitas " & obj.MinSkill & " puntos en Evasion en combate para poder equipar este objeto.", FontTypeNames.FONTTYPE_INFO)
+                        Exit Sub
+                    End If
 
                     'Si esta equipado lo quita
                     If .Invent.Object(Slot).Equipped Then
@@ -1242,12 +1267,18 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                 End If
             
-            Case eOBJType.otescudo
+            Case eOBJType.otEscudo
 
                 If .flags.Navegando = 1 Then Exit Sub
                 
                 If ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) And FaccionPuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
-        
+
+                    'Check skill
+                    If .Stats.UserSkills(eSkill.Defensa) < obj.MinSkill Then
+                        Call WriteConsoleMsg(UserIndex, "Necesitas " & obj.MinSkill & " puntos en Defensa con escudos para poder equipar este objeto.", FontTypeNames.FONTTYPE_INFO)
+                        Exit Sub
+                    End If
+
                     'Si esta equipado lo quita
                     If .Invent.Object(Slot).Equipped Then
                         Call Desequipar(UserIndex, Slot)
@@ -1369,7 +1400,7 @@ End Function
 Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
     '*************************************************
     'Author: Unknown
-    'Last modified: 10/12/2009
+    'Last modified: 03/02/2020
     'Handels the usage of items from inventory box.
     '24/01/2007 Pablo (ToxicWaste) - Agrego el Cuerno de la Armada y la Legion.
     '24/01/2007 Pablo (ToxicWaste) - Utilizacion nueva de Barco en lvl 20 por clase Pirata y Pescador.
@@ -1378,6 +1409,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
     '27/11/2009: Budi - Se envia indivualmente cuando se modifica a la Agilidad o la Fuerza del personaje.
     '08/12/2009: ZaMa - Agrego el uso de hacha de madera elfica.
     '10/12/2009: ZaMa - Arreglos y validaciones en todos las herramientas de trabajo.
+    '03/02/2020: WyroX - Nivel minimo para poder usar y clase prohibida a pergaminos y barcas
     '*************************************************
 
     Dim obj      As ObjData
@@ -1387,7 +1419,9 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
     Dim TargObj  As ObjData
 
     Dim MiObj    As obj
-    
+
+    Dim sMotivo As String
+
     With UserList(UserIndex)
     
         If .Invent.Object(Slot).Amount = 0 Then Exit Sub
@@ -1424,7 +1458,13 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
         
         ' No se pueden usar muebles.
         If Not EsUsable(ObjIndex) Then Exit Sub
-        
+
+        ' Nivel minimo
+        If .Stats.ELV < obj.MinLevel Then
+            Call WriteConsoleMsg(UserIndex, "Necesitas ser nivel " & obj.MinLevel & " para poder usar este objeto.", FontTypeNames.FONTTYPE_INFO)
+            Exit Sub
+        End If
+
         Select Case obj.OBJType
 
             Case eOBJType.otUseOnce
@@ -1855,6 +1895,12 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
                 
                 If .Stats.MaxMAN > 0 Then
                     If .flags.Hambre = 0 And .flags.Sed = 0 Then
+
+                        If Not ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
+                            Call WriteConsoleMsg(UserIndex, sMotivo, FontTypeNames.FONTTYPE_INFO)
+                            Exit Sub
+                        End If
+
                         Call AgregarHechizo(UserIndex, Slot)
                         Call UpdateUserInv(False, UserIndex, Slot)
                     Else
@@ -1948,6 +1994,11 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
                 End If
                
             Case eOBJType.otBarcos
+
+                If Not ClasePuedeUsarItem(UserIndex, ObjIndex, sMotivo) Or Not FaccionPuedeUsarItem(UserIndex, ObjIndex, sMotivo) Then
+                    Call WriteConsoleMsg(UserIndex, sMotivo, FontTypeNames.FONTTYPE_INFO)
+                    Exit Sub
+                End If
 
                 'Verifica si esta aproximado al agua antes de permitirle navegar
                 If .Stats.ELV < 25 Then

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -761,13 +761,13 @@ Public Sub HerreroConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex As I
                 Case eOBJType.otWeapon
                     Call WriteConsoleMsg(UserIndex, "Has construido " & IIf(CantidadItems > 1, CantidadItems & " armas!", "el arma!"), FontTypeNames.FONTTYPE_INFO)
 
-                Case eOBJType.otescudo
+                Case eOBJType.otEscudo
                     Call WriteConsoleMsg(UserIndex, "Has construido " & IIf(CantidadItems > 1, CantidadItems & " escudos!", "el escudo!"), FontTypeNames.FONTTYPE_INFO)
 
-                Case Is = eOBJType.otcasco
+                Case Is = eOBJType.otCasco
                     Call WriteConsoleMsg(UserIndex, "Has construido " & IIf(CantidadItems > 1, CantidadItems & " cascos!", "el casco!"), FontTypeNames.FONTTYPE_INFO)
 
-                Case eOBJType.otarmadura
+                Case eOBJType.otArmadura
                     Call WriteConsoleMsg(UserIndex, "Has construido " & IIf(CantidadItems > 1, CantidadItems & " armaduras", "la armadura!"), FontTypeNames.FONTTYPE_INFO)
         
             End Select
@@ -1305,13 +1305,13 @@ Public Sub DoUpgrade(ByVal UserIndex As Integer, ByVal ItemIndex As Integer)
                 Case eOBJType.otWeapon
                     Call WriteConsoleMsg(UserIndex, "Has mejorado el arma!", FontTypeNames.FONTTYPE_INFO)
                 
-                Case eOBJType.otescudo 'Todavia no hay, pero just in case
+                Case eOBJType.otEscudo 'Todavia no hay, pero just in case
                     Call WriteConsoleMsg(UserIndex, "Has mejorado el escudo!", FontTypeNames.FONTTYPE_INFO)
             
-                Case eOBJType.otcasco
+                Case eOBJType.otCasco
                     Call WriteConsoleMsg(UserIndex, "Has mejorado el casco!", FontTypeNames.FONTTYPE_INFO)
             
-                Case eOBJType.otarmadura
+                Case eOBJType.otArmadura
                     Call WriteConsoleMsg(UserIndex, "Has mejorado la armadura!", FontTypeNames.FONTTYPE_INFO)
 
             End Select
@@ -3181,11 +3181,11 @@ Public Sub DoEquita(ByVal UserIndex As Integer, _
 '***************************************************
     'Dim ModEqui As Long
 
-    'ModEqui = ModEquitacion(UserList(Userindex).clase)
+    'ModEqui = ModEquitacion(UserList(UserIndex).clase)
 
     ' Comento esto por que aun no implementamos en el frmSkills la posibilidad de agregar skills de equitacion
-    'If UserList(Userindex).Stats.UserSkills(Equitacion) / ModEqui < Montura.MinSkill Then
-    '    Call WriteConsoleMsg(Userindex, "Para usar esta montura necesitas " & Montura.MinSkill * ModEqui & " puntos en equitaci�n.", FontTypeNames.FONTTYPE_INFO)
+    'If UserList(UserIndex).Stats.UserSkills(Equitacion) / ModEqui < Montura.MinSkill Then
+    '    Call WriteConsoleMsg(UserIndex, "Para usar esta montura necesitas " & Montura.MinSkill * ModEqui & " puntos en equitaci�n.", FontTypeNames.FONTTYPE_INFO)
     '    Exit Sub
     'End If
 
@@ -3209,7 +3209,7 @@ Public Sub DoEquita(ByVal UserIndex As Integer, _
         End If
 
         ' If .flags.Metamorfosis = 1 Then 'Metamorfosis
-        '     Call WriteConsoleMsg(Userindex, "No puedes montar mientras estas metamorfoseado.", FontTypeNames.FONTTYPE_INFO)
+        '     Call WriteConsoleMsg(UserIndex, "No puedes montar mientras estas metamorfoseado.", FontTypeNames.FONTTYPE_INFO)
         '     Exit Sub
         ' End If
 

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -33,8 +33,6 @@ Public Const HELEMENTAL_FUEGO  As Integer = 26
 
 Public Const HELEMENTAL_TIERRA As Integer = 28
 
-Public Const SUPERANILLO       As Integer = 700
-
 Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, _
                            ByVal UserIndex As Integer, _
                            ByVal Spell As Integer, _
@@ -156,8 +154,8 @@ Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, _
                 
                 Call SendSpellEffects(UserIndex, NpcIndex, Spell, DecirPalabras)
                 
-                If .Invent.AnilloEqpObjIndex = SUPERANILLO Then
-                    Call WriteConsoleMsg(UserIndex, " Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                If ObjData(.Invent.AnilloEqpObjIndex).ImpideParalizar Then
+                    Call WriteConsoleMsg(UserIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
                     Exit Sub
 
                 End If
@@ -183,8 +181,8 @@ Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, _
             
                 Call SendSpellEffects(UserIndex, NpcIndex, Spell, DecirPalabras)
             
-                If .Invent.AnilloEqpObjIndex = SUPERANILLO Then
-                    Call WriteConsoleMsg(UserIndex, " Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                If ObjData(.Invent.AnilloEqpObjIndex).ImpideAturdir Then
+                    Call WriteConsoleMsg(UserIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
                     Exit Sub
 
                 End If
@@ -205,8 +203,8 @@ Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, _
             
                 Call SendSpellEffects(UserIndex, NpcIndex, Spell, DecirPalabras)
             
-                If .Invent.AnilloEqpObjIndex = SUPERANILLO Then
-                    Call WriteConsoleMsg(UserIndex, " Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                If ObjData(.Invent.AnilloEqpObjIndex).ImpideCegar Then
+                    Call WriteConsoleMsg(UserIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
                     Exit Sub
 
                 End If
@@ -1077,7 +1075,7 @@ End Sub
 Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef HechizoCasteado As Boolean)
     '***************************************************
     'Autor: Unknown (orginal version)
-    'Last Modification: 28/04/2010
+    'Last Modification: 03/02/2020
     'Handles the Spells that afect the Stats of an User
     '24/01/2007 Pablo (ToxicWaste) - Invisibilidad no permitida en Mapas con InviSinEfecto
     '26/01/2007 Pablo (ToxicWaste) - Cambios que permiten mejor manejo de ataques en los rings.
@@ -1089,6 +1087,7 @@ Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef HechizoCasteado As Bo
     '23/11/2009: ZaMa - Optimizacion de codigo.
     '28/04/2010: ZaMa - Agrego Restricciones para ciudas respecto al estado atacable.
     '16/09/2010: ZaMa - Solo se hace invi para los clientes si no esta navegando.
+    '03/02/2020: WyroX - Anillos anti-efectos
     '***************************************************
 
     Dim HechizoIndex As Integer
@@ -1327,9 +1326,9 @@ Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef HechizoCasteado As Bo
                 Call InfoHechizo(UserIndex)
                 HechizoCasteado = True
 
-                If UserList(targetIndex).Invent.AnilloEqpObjIndex = SUPERANILLO Then
-                    Call WriteConsoleMsg(targetIndex, " Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
-                    Call WriteConsoleMsg(UserIndex, " El hechizo no tiene efecto!", FontTypeNames.FONTTYPE_FIGHT)
+                If ObjData(UserList(targetIndex).Invent.AnilloEqpObjIndex).ImpideParalizar Then
+                    Call WriteConsoleMsg(targetIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                    Call WriteConsoleMsg(UserIndex, "El hechizo no tiene efecto!", FontTypeNames.FONTTYPE_FIGHT)
                     Call FlushBuffer(targetIndex)
                     Exit Sub
 
@@ -1539,7 +1538,13 @@ Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef HechizoCasteado As Bo
             End If
             
             If Not PuedeAtacar(UserIndex, targetIndex) Then Exit Sub
-            
+
+            If ObjData(UserList(targetIndex).Invent.AnilloEqpObjIndex).ImpideCegar Then
+                Call WriteConsoleMsg(targetIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                Call WriteConsoleMsg(UserIndex, "El hechizo no tiene efecto!", FontTypeNames.FONTTYPE_FIGHT)
+                Exit Sub
+            End If
+
             If UserIndex <> targetIndex Then
                 Call UsuarioAtacadoPorUsuario(UserIndex, targetIndex)
 
@@ -1570,6 +1575,13 @@ Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef HechizoCasteado As Bo
             End If
             
             If Not PuedeAtacar(UserIndex, targetIndex) Then Exit Sub
+
+            If ObjData(UserList(targetIndex).Invent.AnilloEqpObjIndex).ImpideAturdir Then
+                Call WriteConsoleMsg(targetIndex, "Tu anillo rechaza los efectos del hechizo.", FontTypeNames.FONTTYPE_FIGHT)
+                Call WriteConsoleMsg(UserIndex, "El hechizo no tiene efecto!", FontTypeNames.FONTTYPE_FIGHT)
+                Exit Sub
+            End If
+
             If UserIndex <> targetIndex Then
                 Call UsuarioAtacadoPorUsuario(UserIndex, targetIndex)
 

--- a/Codigo/modHungerGames.bas
+++ b/Codigo/modHungerGames.bas
@@ -424,7 +424,7 @@ Public Function ArmaduraRandom() As Integer
         YAObjIndex = RandomNumber(1, NumObjDatas)
    
         'Ya tengo?
-        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otarmadura)
+        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otArmadura)
 
         If (ObjData(YAObjIndex).Real <> 0) Or (ObjData(YAObjIndex).Caos <> 0) Or (ObjData(YAObjIndex).NoSeCae <> 0) Or (ObjData(YAObjIndex).MinDef >= 30) Then
             YATengo = False
@@ -476,7 +476,7 @@ Public Function CascoRandom() As Integer
         YAObjIndex = RandomNumber(1, NumObjDatas)
    
         'Ya tengo?
-        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otcasco)
+        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otCasco)
 
         If (ObjData(YAObjIndex).MinDef >= 20) Or (ObjData(YAObjIndex).Real <> 0) Or (ObjData(YAObjIndex).Caos <> 0) Or (ObjData(YAObjIndex).NoSeCae <> 0) Then
             YATengo = False
@@ -502,7 +502,7 @@ Public Function EscudoRandom() As Integer
         YAObjIndex = RandomNumber(1, NumObjDatas)
    
         'Ya tengo?
-        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otescudo)
+        YATengo = (ObjData(YAObjIndex).OBJType = eOBJType.otEscudo)
 
         If (ObjData(YAObjIndex).Real <> 0) Or (ObjData(YAObjIndex).Caos <> 0) Or (ObjData(YAObjIndex).NoSeCae <> 0) Then
             YATengo = False


### PR DESCRIPTION
Podés agregar "MinSkill" a armas, escudos, cascos y armaduras para exigir que el usuario tenga el skill correspondiente (Combate con armas y Evasión en combate).
Podés agregar "MinLevel" a lo anterior, a barcos, flechas, monturas, anillos, mochilas y pergaminos; para requerir un nivel mínimo para poder usar o equipar.
Podés agregar "ImpideParalizar", "ImpideAturdir" e "ImpideCegar" para dar anti-efectos a un anillo.
Ahora los pergaminos tienen en cuenta si no pueden ser usados por una clase.