### PR TITLE
Limpieza del código relacionado con el manejo de Sockets/Winsocks/TCPServ.

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -239,29 +239,6 @@ Sub EnviarSpawnList(ByVal Userindex As Integer)
 
 End Sub
 
-Sub ConfigListeningSocket(ByRef obj As Object, ByVal Port As Integer)
-    '***************************************************
-    'Author: Unknown
-    'Last Modification: -
-    '
-    '***************************************************
-
-    #If UsarQueSocket = 0 Then
-
-        obj.AddressFamily = AF_INET
-        obj.Protocol = IPPROTO_IP
-        obj.SocketType = SOCK_STREAM
-        obj.Binary = False
-        obj.Blocking = False
-        obj.BufferSize = 1024
-        obj.LocalPort = Port
-        obj.backlog = 5
-        obj.listen
-
-    #End If
-
-End Sub
-
 Public Function GetVersionOfTheServer() As String
     GetVersionOfTheServer = GetVar(App.Path & "\Server.ini", "INIT", "VersionTagRelease")
 End Function
@@ -638,47 +615,20 @@ Private Sub SocketConfig()
 
     Call SecurityIp.InitIpTables(1000)
     
-    #If UsarQueSocket = 1 Then
-    
-        If LastSockListen >= 0 Then
-            Call apiclosesocket(LastSockListen) 'Cierra el socket de escucha
-        End If
+    If LastSockListen >= 0 Then
+        Call apiclosesocket(LastSockListen) 'Cierra el socket de escucha
+    End If
 
-        Call IniciaWsApi(frmMain.hWnd)
-        SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
+    Call IniciaWsApi(frmMain.hWnd)
+    
+    SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
-        If SockListen <> -1 Then
-            ' Guarda el socket escuchando
-            Call WriteVar(IniPath & "Server.ini", "INIT", "LastSockListen", SockListen)
-        Else
-            Call MsgBox("Ha ocurrido un error al iniciar el socket del Servidor.", vbCritical + vbOKOnly)
-        End If
-    
-    #ElseIf UsarQueSocket = 0 Then
-    
-        frmCargando.Label1(2).Caption = "Configurando Sockets"
-    
-        frmMain.Socket2(0).AddressFamily = AF_INET
-        frmMain.Socket2(0).Protocol = IPPROTO_IP
-        frmMain.Socket2(0).SocketType = SOCK_STREAM
-        frmMain.Socket2(0).Binary = False
-        frmMain.Socket2(0).Blocking = False
-        frmMain.Socket2(0).BufferSize = 2048
-    
-        Call ConfigListeningSocket(frmMain.Socket1, Puerto)
-    
-    #ElseIf UsarQueSocket = 2 Then
-    
-        frmMain.Serv.Iniciar Puerto
-    
-    #ElseIf UsarQueSocket = 3 Then
-    
-        frmMain.TCPServ.Encolar True
-        frmMain.TCPServ.IniciarTabla 1009
-        frmMain.TCPServ.SetQueueLim 51200
-        frmMain.TCPServ.Iniciar Puerto
-    
-    #End If
+    If SockListen <> -1 Then
+        ' Guarda el socket escuchando
+        Call WriteVar(IniPath & "Server.ini", "INIT", "LastSockListen", SockListen)
+    Else
+        Call MsgBox("Ha ocurrido un error al iniciar el socket del Servidor.", vbCritical + vbOKOnly)
+    End If
     
     frmMain.txtStatus.Text = Date & " " & time & " - Escuchando conexiones entrantes ..."
     
@@ -782,26 +732,13 @@ Sub Restart()
     If frmMain.Visible Then frmMain.txtStatus.Text = "Reiniciando."
     
     Dim LoopC As Long
-  
-    #If UsarQueSocket = 0 Then
 
-        frmMain.Socket1.Cleanup
-        frmMain.Socket1.Startup
-      
-        frmMain.Socket2(0).Cleanup
-        frmMain.Socket2(0).Startup
 
-    #ElseIf UsarQueSocket = 1 Then
-
-        'Cierra el socket de escucha
-        If SockListen >= 0 Then Call apiclosesocket(SockListen)
+    'Cierra el socket de escucha
+    If SockListen >= 0 Then Call apiclosesocket(SockListen)
     
-        'Inicia el socket de escucha
-        SockListen = ListenForConnect(Puerto, hWndMsg, "")
-
-    #ElseIf UsarQueSocket = 2 Then
-
-    #End If
+    'Inicia el socket de escucha
+    SockListen = ListenForConnect(Puerto, hWndMsg, "")
 
     For LoopC = 1 To MaxUsers
         Call CloseSocket(LoopC)
@@ -838,32 +775,6 @@ Sub Restart()
     Call LoadMapData
     
     Call CargarHechizos
-
-    #If UsarQueSocket = 0 Then
-
-        '*****************Setup socket
-        frmMain.Socket1.AddressFamily = AF_INET
-        frmMain.Socket1.Protocol = IPPROTO_IP
-        frmMain.Socket1.SocketType = SOCK_STREAM
-        frmMain.Socket1.Binary = False
-        frmMain.Socket1.Blocking = False
-        frmMain.Socket1.BufferSize = 1024
-    
-        frmMain.Socket2(0).AddressFamily = AF_INET
-        frmMain.Socket2(0).Protocol = IPPROTO_IP
-        frmMain.Socket2(0).SocketType = SOCK_STREAM
-        frmMain.Socket2(0).Blocking = False
-        frmMain.Socket2(0).BufferSize = 2048
-    
-        'Escucha
-        frmMain.Socket1.LocalPort = val(Puerto)
-        frmMain.Socket1.listen
-
-    #ElseIf UsarQueSocket = 1 Then
-
-    #ElseIf UsarQueSocket = 2 Then
-
-    #End If
 
     If frmMain.Visible Then frmMain.txtStatus.Text = Date & " " & time & " servidor reiniciado correctamente. - Escuchando conexiones entrantes ..."
     
@@ -1633,7 +1544,7 @@ Sub SaveUser(ByVal Userindex As Integer, Optional ByVal SaveTimeOnline As Boolea
 
     With UserList(Userindex)
 
-        If .clase = 0 Or .Stats.ELV = 0 Then
+        If .Clase = 0 Or .Stats.ELV = 0 Then
             Call LogCriticEvent("Estoy intentantdo guardar un usuario nulo de nombre: " & .Name)
             Exit Sub
 

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -36,217 +36,7 @@ Option Explicit
 
 #If False Then
 
-    Dim X, Y, n, mapa, Email, Length As Variant
-
-#End If
-
-#If UsarQueSocket = 0 Then
-
-    ' General constants used with most of the controls
-    Public Const INVALID_HANDLE     As Integer = -1
-
-    Public Const CONTROL_ERRIGNORE  As Integer = 0
-
-    Public Const CONTROL_ERRDISPLAY As Integer = 1
-
-    ' SocietWrench Control Actions
-    Public Const SOCKET_OPEN        As Integer = 1
-
-    Public Const SOCKET_CONNECT     As Integer = 2
-
-    Public Const SOCKET_LISTEN      As Integer = 3
-
-    Public Const SOCKET_ACCEPT      As Integer = 4
-
-    Public Const SOCKET_CANCEL      As Integer = 5
-
-    Public Const SOCKET_FLUSH       As Integer = 6
-
-    Public Const SOCKET_CLOSE       As Integer = 7
-
-    Public Const SOCKET_DISCONNECT  As Integer = 7
-
-    Public Const SOCKET_ABORT       As Integer = 8
-
-    ' SocketWrench Control States
-    Public Const SOCKET_NONE        As Integer = 0
-
-    Public Const SOCKET_IDLE        As Integer = 1
-
-    Public Const SOCKET_LISTENING   As Integer = 2
-
-    Public Const SOCKET_CONNECTING  As Integer = 3
-
-    Public Const SOCKET_ACCEPTING   As Integer = 4
-
-    Public Const SOCKET_RECEIVING   As Integer = 5
-
-    Public Const SOCKET_SENDING     As Integer = 6
-
-    Public Const SOCKET_CLOSING     As Integer = 7
-
-    ' Societ Address Families
-    Public Const AF_UNSPEC          As Integer = 0
-
-    Public Const AF_UNIX            As Integer = 1
-
-    Public Const AF_INET            As Integer = 2
-
-    ' Societ Types
-    Public Const SOCK_STREAM        As Integer = 1
-
-    Public Const SOCK_DGRAM         As Integer = 2
-
-    Public Const SOCK_RAW           As Integer = 3
-
-    Public Const SOCK_RDM           As Integer = 4
-
-    Public Const SOCK_SEQPACKET     As Integer = 5
-
-    ' Protocol Types
-    Public Const IPPROTO_IP         As Integer = 0
-
-    Public Const IPPROTO_ICMP       As Integer = 1
-
-    Public Const IPPROTO_GGP        As Integer = 2
-
-    Public Const IPPROTO_TCP        As Integer = 6
-
-    Public Const IPPROTO_PUP        As Integer = 12
-
-    Public Const IPPROTO_UDP        As Integer = 17
-
-    Public Const IPPROTO_IDP        As Integer = 22
-
-    Public Const IPPROTO_ND         As Integer = 77
-
-    Public Const IPPROTO_RAW        As Integer = 255
-
-    Public Const IPPROTO_MAX        As Integer = 256
-
-    ' Network Addpesses
-    Public Const INADDR_ANY         As String = "0.0.0.0"
-
-    Public Const INADDR_LOOPBACK    As String = "127.0.0.1"
-
-    Public Const INADDR_NONE        As String = "255.055.255.255"
-
-    ' Shutdown Values
-    Public Const SOCKET_READ        As Integer = 0
-
-    Public Const SOCKET_WRITE       As Integer = 1
-
-    Public Const SOCKET_READWRITE   As Integer = 2
-
-    ' SocketWrench Error Pesponse
-    Public Const SOCKET_ERRIGNORE   As Integer = 0
-
-    Public Const SOCKET_ERRDISPLAY  As Integer = 1
-
-    ' SocketWrench Error Codes
-    Public Const WSABASEERR         As Integer = 24000
-
-    Public Const WSAEINTR           As Integer = 24004
-
-    Public Const WSAEBADF           As Integer = 24009
-
-    Public Const WSAEACCES          As Integer = 24013
-
-    Public Const WSAEFAULT          As Integer = 24014
-
-    Public Const WSAEINVAL          As Integer = 24022
-
-    Public Const WSAEMFILE          As Integer = 24024
-
-    Public Const WSAEWOULDBLOCK     As Integer = 24035
-
-    Public Const WSAEINPROGRESS     As Integer = 24036
-
-    Public Const WSAEALREADY        As Integer = 24037
-
-    Public Const WSAENOTSOCK        As Integer = 24038
-
-    Public Const WSAEDESTADDRREQ    As Integer = 24039
-
-    Public Const WSAEMSGSIZE        As Integer = 24040
-
-    Public Const WSAEPROTOTYPE      As Integer = 24041
-
-    Public Const WSAENOPROTOOPT     As Integer = 24042
-
-    Public Const WSAEPROTONOSUPPORT As Integer = 24043
-
-    Public Const WSAESOCKTNOSUPPORT As Integer = 24044
-
-    Public Const WSAEOPNOTSUPP      As Integer = 24045
-
-    Public Const WSAEPFNOSUPPORT    As Integer = 24046
-
-    Public Const WSAEAFNOSUPPORT    As Integer = 24047
-
-    Public Const WSAEADDRINUSE      As Integer = 24048
-
-    Public Const WSAEADDRNOTAVAIL   As Integer = 24049
-
-    Public Const WSAENETDOWN        As Integer = 24050
-
-    Public Const WSAENETUNREACH     As Integer = 24051
-
-    Public Const WSAENETRESET       As Integer = 24052
-
-    Public Const WSAECONNABORTED    As Integer = 24053
-
-    Public Const WSAECONNRESET      As Integer = 24054
-
-    Public Const WSAENOBUFS         As Integer = 24055
-
-    Public Const WSAEISCONN         As Integer = 24056
-
-    Public Const WSAENOTCONN        As Integer = 24057
-
-    Public Const WSAESHUTDOWN       As Integer = 24058
-
-    Public Const WSAETOOMANYREFS    As Integer = 24059
-
-    Public Const WSAETIMEDOUT       As Integer = 24060
-
-    Public Const WSAECONNREFUSED    As Integer = 24061
-
-    Public Const WSAELOOP           As Integer = 24062
-
-    Public Const WSAENAMETOOLONG    As Integer = 24063
-
-    Public Const WSAEHOSTDOWN       As Integer = 24064
-
-    Public Const WSAEHOSTUNREACH    As Integer = 24065
-
-    Public Const WSAENOTEMPTY       As Integer = 24066
-
-    Public Const WSAEPROCLIM        As Integer = 24067
-
-    Public Const WSAEUSERS          As Integer = 24068
-
-    Public Const WSAEDQUOT          As Integer = 24069
-
-    Public Const WSAESTALE          As Integer = 24070
-
-    Public Const WSAEREMOTE         As Integer = 24071
-
-    Public Const WSASYSNOTREADY     As Integer = 24091
-
-    Public Const WSAVERNOTSUPPORTED As Integer = 24092
-
-    Public Const WSANOTINITIALISED  As Integer = 24093
-
-    Public Const WSAHOST_NOT_FOUND  As Integer = 25001
-
-    Public Const WSATRY_AGAIN       As Integer = 25002
-
-    Public Const WSANO_RECOVERY     As Integer = 25003
-
-    Public Const WSANO_DATA         As Integer = 25004
-
-    Public Const WSANO_ADDRESS      As Integer = 2500
+    Dim X, Y, n, Mapa, Email, Length As Variant
 
 #End If
 
@@ -597,7 +387,7 @@ Sub ConnectNewUser(ByVal Userindex As Integer, _
         .Reputacion.Promedio = 30 / 6
     
         .Name = Name
-        .clase = UserClase
+        .Clase = UserClase
         .raza = UserRaza
         .Genero = UserSexo
         .Hogar = Hogar
@@ -1037,219 +827,110 @@ Sub ConnectAccount(ByVal Userindex As Integer, _
     Else
         Call SaveAccountLastLoginDatabase(UserName, UserList(Userindex).IP)
         Call LoginAccountDatabase(Userindex, UserName)
-
     End If
 
 End Sub
 
-#If UsarQueSocket = 1 Or UsarQueSocket = 2 Then
-
-    Sub CloseSocket(ByVal Userindex As Integer, Optional ByVal Reconnect As Boolean = False)
-        '***************************************************
-        'Author: Unknown
-        'Last Modification: -
-        '
-        '***************************************************
-
-        On Error GoTo ErrHandler
-
-        With UserList(Userindex)
-            If Not Reconnect Then
-                Call SecurityIp.IpRestarConexion(GetLongIp(.IP))
-            
-                If .ConnID <> -1 Then
-                    Call CloseSocketSL(Userindex)
-    
-                End If
-            End If
-            ' Hunger Games
-            If .flags.SG.HungerIndex <> 0 Then modHungerGames.HungerDesconect Userindex
-        
-            'Nuevo centinela - maTih.-
-            If .CentinelaUsuario.centinelaIndex <> 0 Then
-                Call modCentinela.UsuarioInActivo(Userindex)
-
-            End If
-        
-            'mato los comercios seguros
-            If .ComUsu.DestUsu > 0 Then
-                If UserList(.ComUsu.DestUsu).flags.UserLogged Then
-                    If UserList(.ComUsu.DestUsu).ComUsu.DestUsu = Userindex Then
-                        Call WriteConsoleMsg(.ComUsu.DestUsu, "Comercio cancelado por el otro usuario", FontTypeNames.FONTTYPE_WARNING)
-                        Call FinComerciarUsu(.ComUsu.DestUsu)
-                        Call FlushBuffer(.ComUsu.DestUsu)
-
-                    End If
-
-                End If
-
-            End If
-            
-            ' Retos nVSn. Usuario cierra conexion.
-            If .flags.SlotReto > 0 Then
-                Call Retos.UserDieFight(Userindex, 0, True)
-            End If
-
-            ' Desequipamos la montura justo antes de cerrar el socket
-            ' para prevenir que se la equipe durante el conteo de salida (WyroX)
-            If .flags.Equitando = 1 Then
-                Call UnmountMontura(Userindex)
-            End If
-            
-            'Empty buffer for reuse
-            Call .incomingData.ReadASCIIStringFixed(.incomingData.Length)
-        
-            If .flags.UserLogged Then
-                If NumUsers > 0 Then NumUsers = NumUsers - 1
-                Call CloseUser(Userindex, Reconnect)
-            
-            Else
-                Call ResetUserSlot(Userindex, Reconnect)
-
-            End If
-            
-            Call LiberarSlot(Userindex, Reconnect)
-            
-        End With
-
-        Exit Sub
-
-ErrHandler:
-
-        Call ResetUserSlot(Userindex)
-        
-        Call LiberarSlot(Userindex)
-        
-        Call LogError("CloseSocket - Error = " & Err.Number & " - Descripcion = " & Err.description & " - UserIndex = " & Userindex)
-
-    End Sub
-
-#ElseIf UsarQueSocket = 0 Then
-
-Sub CloseSocket(ByVal Userindex As Integer)
-'***************************************************
-'Author: Unknown
-'Last Modification: -
-'
-'***************************************************
-
-On Error GoTo ErrHandler
-    UserList(Userindex).ConnID = -1
-
-    Call LiberarSlot(Userindex)
-
-    If UserList(Userindex).flags.UserLogged Then
-            If NumUsers <> 0 Then NumUsers = NumUsers - 1
-            Call CloseUser(Userindex)
-    End If
-
-    frmMain.Socket2(Userindex).Cleanup
-    Unload frmMain.Socket2(Userindex)
-    Call ResetUserSlot(Userindex)
-
-Exit Sub
-
-ErrHandler:
-    UserList(Userindex).ConnID = -1
-    Call ResetUserSlot(Userindex)
-End Sub
-
-
-#ElseIf UsarQueSocket = 3 Then
-
-Sub CloseSocket(ByVal Userindex As Integer, Optional ByVal cerrarlo As Boolean = True)
-'***************************************************
-'Author: Unknown
-'Last Modification: -
-'
-'***************************************************
-On Error GoTo ErrHandler
-
-Dim NURestados As Boolean
-Dim CoNnEcTiOnId As Long
-
-
-    NURestados = False
-    CoNnEcTiOnId = UserList(Userindex).ConnID
-    
-    'call logindex(UserIndex, "******> Sub CloseSocket. ConnId: " & CoNnEcTiOnId & " Cerrarlo: " & Cerrarlo)
-  
-    UserList(Userindex).ConnID = -1 'inabilitamos operaciones en socket
-
-    Call LiberarSlot(Userindex)
-
-    If UserList(Userindex).flags.UserLogged Then
-            If NumUsers <> 0 Then NumUsers = NumUsers - 1
-            NURestados = True
-            Call CloseUser(Userindex)
-    End If
-    
-    Call ResetUserSlot(Userindex)
-    
-    'limpiada la userlist... reseteo el socket, si me lo piden
-    'Me lo piden desde: cerrada intecional del servidor (casi todas
-    'las llamadas a CloseSocket del codigo)
-    'No me lo piden desde: disconnect remoto (el on_close del control
-    'de alejo realiza la desconexion automaticamente). Esto puede pasar
-    'por ejemplo, si el cliente cierra el AO.
-    If cerrarlo Then Call frmMain.TCPServ.CerrarSocket(CoNnEcTiOnId)
-
-Exit Sub
-
-ErrHandler:
-    Call LogError("CLOSESOCKETERR: " & Err.description & " UI:" & Userindex)
-    
-    If Not NURestados Then
-        If UserList(Userindex).flags.UserLogged Then
-            If NumUsers > 0 Then
-                NumUsers = NumUsers - 1
-            End If
-            Call LogError("Cerre sin grabar a: " & UserList(Userindex).Name)
-        End If
-    End If
-    
-    Call LogError("El usuario no guardado tenia ConnID " & CoNnEcTiOnId & ". Socket no liberado.")
-    Call ResetUserSlot(Userindex)
-
-End Sub
-
-#End If
-
-'[Alejo-21-5]: Cierra un socket sin limpiar el slot
-Sub CloseSocketSL(ByVal Userindex As Integer)
+Sub CloseSocket(ByVal Userindex As Integer, Optional ByVal Reconnect As Boolean = False)
     '***************************************************
     'Author: Unknown
     'Last Modification: -
     '
     '***************************************************
 
-    #If UsarQueSocket = 1 Then
+    On Error GoTo ErrHandler
 
-        If UserList(Userindex).ConnID <> -1 And UserList(Userindex).ConnIDValida Then
-            Call BorraSlotSock(UserList(Userindex).ConnID)
-            Call WSApiCloseSocket(UserList(Userindex).ConnID)
-            UserList(Userindex).ConnIDValida = False
+    With UserList(Userindex)
 
-        End If
-
-    #ElseIf UsarQueSocket = 0 Then
-
-        If UserList(Userindex).ConnID <> -1 And UserList(Userindex).ConnIDValida Then
-            frmMain.Socket2(Userindex).Cleanup
-            Unload frmMain.Socket2(Userindex)
-            UserList(Userindex).ConnIDValida = False
+        If Not Reconnect Then
+            Call SecurityIp.IpRestarConexion(GetLongIp(.IP))
+            
+            If .ConnID <> -1 Then
+                Call CloseSocketSL(Userindex)
+    
+            End If
 
         End If
 
-    #ElseIf UsarQueSocket = 2 Then
+        ' Hunger Games
+        If .flags.SG.HungerIndex <> 0 Then modHungerGames.HungerDesconect Userindex
+        
+        'Nuevo centinela - maTih.-
+        If .CentinelaUsuario.centinelaIndex <> 0 Then
+            Call modCentinela.UsuarioInActivo(Userindex)
+        End If
+        
+        'mato los comercios seguros
+        If .ComUsu.DestUsu > 0 Then
+            
+            If UserList(.ComUsu.DestUsu).flags.UserLogged Then
+                
+                If UserList(.ComUsu.DestUsu).ComUsu.DestUsu = Userindex Then
+                    
+                    Call WriteConsoleMsg(.ComUsu.DestUsu, "Comercio cancelado por el otro usuario", FontTypeNames.FONTTYPE_WARNING)
+                    Call FinComerciarUsu(.ComUsu.DestUsu)
+                    Call FlushBuffer(.ComUsu.DestUsu)
 
-        If UserList(Userindex).ConnID <> -1 And UserList(Userindex).ConnIDValida Then
-            Call frmMain.Serv.CerrarSocket(UserList(Userindex).ConnID)
-            UserList(Userindex).ConnIDValida = False
+                End If
+
+            End If
+
+        End If
+            
+        ' Retos nVSn. Usuario cierra conexion.
+        If .flags.SlotReto > 0 Then
+            Call Retos.UserDieFight(Userindex, 0, True)
 
         End If
 
-    #End If
+        ' Desequipamos la montura justo antes de cerrar el socket
+        ' para prevenir que se la equipe durante el conteo de salida (WyroX)
+        If .flags.Equitando = 1 Then
+            Call UnmountMontura(Userindex)
+
+        End If
+            
+        'Empty buffer for reuse
+        Call .incomingData.ReadASCIIStringFixed(.incomingData.Length)
+        
+        If .flags.UserLogged Then
+            If NumUsers > 0 Then NumUsers = NumUsers - 1
+            Call CloseUser(Userindex, Reconnect)
+        Else
+            Call ResetUserSlot(Userindex, Reconnect)
+        End If
+            
+        Call LiberarSlot(Userindex, Reconnect)
+            
+    End With
+
+    Exit Sub
+
+ErrHandler:
+
+    Call ResetUserSlot(Userindex)
+        
+    Call LiberarSlot(Userindex)
+        
+    Call LogError("CloseSocket - Error = " & Err.Number & " - Descripcion = " & Err.description & " - UserIndex = " & Userindex)
+
+End Sub
+
+'[Alejo-21-5]: Cierra un socket sin limpiar el slot
+Sub CloseSocketSL(ByVal Userindex As Integer)
+    
+    '***************************************************
+    'Author: Unknown
+    'Last Modification: -
+    '
+    '***************************************************
+
+    If UserList(Userindex).ConnID <> -1 And UserList(Userindex).ConnIDValida Then
+        Call BorraSlotSock(UserList(Userindex).ConnID)
+        Call WSApiCloseSocket(UserList(Userindex).ConnID)
+        UserList(Userindex).ConnIDValida = False
+
+    End If
 
 End Sub
 
@@ -1258,10 +939,7 @@ End Sub
 '
 ' @param userIndex The index of the User
 ' @param Datos The string that will be send
-' @remarks If UsarQueSocket is 3 it won`t use the clsByteQueue
-
-Public Function EnviarDatosASlot(ByVal Userindex As Integer, _
-                                 ByRef Datos As String) As Long
+Public Function EnviarDatosASlot(ByVal Userindex As Integer, ByRef Datos As String) As Long
     '***************************************************
     'Author: Unknown
     'Last Modification: 01/10/07
@@ -1269,79 +947,20 @@ Public Function EnviarDatosASlot(ByVal Userindex As Integer, _
     'Now it uses the clsByteQueue class and don`t make a FIFO Queue of String
     '***************************************************
 
-    #If UsarQueSocket = 1 Then '**********************************************
-
-        On Error GoTo Err
+    On Error GoTo Err
     
-        Dim ret As Long
-    
+    Dim ret As Long
         ret = WsApiEnviar(Userindex, Datos)
     
-        If ret <> 0 And ret <> WSAEWOULDBLOCK Then
-            ' Close the socket avoiding any critical error
-            Call CloseSocketSL(Userindex)
-            Call Cerrar_Usuario(Userindex)
+    If ret <> 0 And ret <> WSAEWOULDBLOCK Then
+        ' Close the socket avoiding any critical error
+        Call CloseSocketSL(Userindex)
+        Call Cerrar_Usuario(Userindex)
+    End If
 
-        End If
-
-        Exit Function
+    Exit Function
     
 Err:
-
-    #ElseIf UsarQueSocket = 0 Then '**********************************************
-    
-        If frmMain.Socket2(Userindex).Write(Datos, Len(Datos)) < 0 Then
-            If frmMain.Socket2(Userindex).LastError = WSAEWOULDBLOCK Then
-                ' WSAEWOULDBLOCK, put the data again in the outgoingData Buffer
-                Call UserList(Userindex).outgoingData.WriteASCIIStringFixed(Datos)
-            Else
-                'Close the socket avoiding any critical error
-                Call Cerrar_Usuario(Userindex)
-
-            End If
-
-        End If
-
-    #ElseIf UsarQueSocket = 2 Then '**********************************************
-
-        'Return value for this Socket:
-        '--0) OK
-        '--1) WSAEWOULDBLOCK
-        '--2) ERROR
-    
-        Dim ret As Long
-
-        ret = frmMain.Serv.Enviar(.ConnID, Datos, Len(Datos))
-            
-        If ret = 1 Then
-            ' WSAEWOULDBLOCK, put the data again in the outgoingData Buffer
-            Call .outgoingData.WriteASCIIStringFixed(Datos)
-        ElseIf ret = 2 Then
-            'Close socket avoiding any critical error
-            Call CloseSocketSL(Userindex)
-            Call Cerrar_Usuario(Userindex)
-
-        End If
-
-    #ElseIf UsarQueSocket = 3 Then
-
-        'THIS SOCKET DOESN`T USE THE BYTE QUEUE CLASS
-        'al carajo, esto encola solo!!! che, me aprobara los
-        'parciales tambien?, este control hace todo solo!!!!
-        On Error GoTo ErrorHandler
-        
-        If UserList(Userindex).ConnID = -1 Then
-            Call LogError("TCP::EnviardatosASlot, se intento enviar datos a un userIndex con ConnId=-1")
-            Exit Function
-
-        End If
-        
-        If frmMain.TCPServ.Enviar(UserList(Userindex).ConnID, Datos, Len(Datos)) = 2 Then Call CloseSocket(Userindex)
-
-        Exit Function
-ErrorHandler:
-        Call LogError("TCP::EnviarDatosASlot. UI/ConnId/Datos: " & Userindex & "/" & UserList(Userindex).ConnID & "/" & Datos)
-    #End If '**********************************************
 
 End Function
 
@@ -1607,31 +1226,31 @@ Sub ConnectUser(ByVal Userindex As Integer, _
 
         End If
     
-        Dim mapa As Integer
+        Dim Mapa As Integer
 
-        mapa = .Pos.Map
+        Mapa = .Pos.Map
     
         'Posicion de comienzo
-        If mapa = 0 Then
+        If Mapa = 0 Then
 
             'Configurable desde el Server.ini / CustomWorld
             'En caso que usemos mundo propio, cargamos el mapa y la coordeanas donde se hara el spawn inicial'
             'Caso contrario sigue modo Alkon'
             If UsarMundoPropio Then
                 .Pos = CustomSpawnMap
-                mapa = CustomSpawnMap.Map
+                Mapa = CustomSpawnMap.Map
             Else
                 'Dejo esto comentado aqui por si se quiere utilizar la ciudad elegida desde el menu
                 'Crear personaje, ahora se utiliza solo Nemahuak ya que es una ciudad nw utilizada desde la 0.13
                 ' .Pos = Ciudades(.Hogar)
                 ' mapa = Ciudades(.Hogar).Map
                 .Pos = Nemahuak
-                mapa = Nemahuak.Map
+                Mapa = Nemahuak.Map
             End If
 
         Else
     
-            If Not MapaValido(mapa) Then
+            If Not MapaValido(Mapa) Then
                 Call WriteErrorMsg(Userindex, "El PJ se encuenta en un mapa invalido.")
                 Call CloseSocket(Userindex)
                 Exit Sub
@@ -1641,12 +1260,12 @@ Sub ConnectUser(ByVal Userindex As Integer, _
             ' If map has different initial coords, update it
             Dim StartMap As Integer
 
-            StartMap = MapInfo(mapa).StartPos.Map
+            StartMap = MapInfo(Mapa).StartPos.Map
 
             If StartMap <> 0 Then
                 If MapaValido(StartMap) Then
-                    .Pos = MapInfo(mapa).StartPos
-                    mapa = StartMap
+                    .Pos = MapInfo(Mapa).StartPos
+                    Mapa = StartMap
 
                 End If
 
@@ -1656,7 +1275,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
     
         'Tratamos de evitar en lo posible el "Telefrag". Solo 1 intento de loguear en pos adjacentes.
         'Codigo por Pablo (ToxicWaste) y revisado por Nacho (Integer), corregido para que realmetne ande y no tire el server por Juan Martin Sotuyo Dodero (Maraxus)
-        If MapData(mapa, .Pos.X, .Pos.Y).Userindex <> 0 Or MapData(mapa, .Pos.X, .Pos.Y).NpcIndex <> 0 Then
+        If MapData(Mapa, .Pos.X, .Pos.Y).Userindex <> 0 Or MapData(Mapa, .Pos.X, .Pos.Y).NpcIndex <> 0 Then
 
             Dim FoundPlace As Boolean
 
@@ -1667,7 +1286,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
             Dim tY         As Long
         
             FoundPlace = False
-            esAgua = HayAgua(mapa, .Pos.X, .Pos.Y)
+            esAgua = HayAgua(Mapa, .Pos.X, .Pos.Y)
         
             For tY = .Pos.Y - 1 To .Pos.Y + 1
                 For tX = .Pos.X - 1 To .Pos.X + 1
@@ -1675,7 +1294,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
                     If esAgua Then
 
                         'reviso que sea pos legal en agua, que no haya User ni NPC para poder loguear.
-                        If LegalPos(mapa, tX, tY, True, False) Then
+                        If LegalPos(Mapa, tX, tY, True, False) Then
                             FoundPlace = True
                             Exit For
 
@@ -1684,7 +1303,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
                     Else
 
                         'reviso que sea pos legal en tierra, que no haya User ni NPC para poder loguear.
-                        If LegalPos(mapa, tX, tY, False, True) Then
+                        If LegalPos(Mapa, tX, tY, False, True) Then
                             FoundPlace = True
                             Exit For
 
@@ -1703,30 +1322,30 @@ Sub ConnectUser(ByVal Userindex As Integer, _
             Else
 
                 'Si no encontramos un lugar, sacamos al usuario que tenemos abajo, y si es un NPC, lo pisamos.
-                If MapData(mapa, .Pos.X, .Pos.Y).Userindex <> 0 Then
+                If MapData(Mapa, .Pos.X, .Pos.Y).Userindex <> 0 Then
 
                     'Si no encontramos lugar, y abajo teniamos a un usuario, lo pisamos y cerramos su comercio seguro
-                    If UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu > 0 Then
+                    If UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu > 0 Then
 
                         'Le avisamos al que estaba comerciando que se tuvo que ir.
-                        If UserList(UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu).flags.UserLogged Then
-                            Call FinComerciarUsu(UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu)
-                            Call WriteConsoleMsg(UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu, "Comercio cancelado. El otro usuario se ha desconectado.", FontTypeNames.FONTTYPE_WARNING)
-                            Call FlushBuffer(UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu)
+                        If UserList(UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu).flags.UserLogged Then
+                            Call FinComerciarUsu(UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu)
+                            Call WriteConsoleMsg(UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu, "Comercio cancelado. El otro usuario se ha desconectado.", FontTypeNames.FONTTYPE_WARNING)
+                            Call FlushBuffer(UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).ComUsu.DestUsu)
 
                         End If
 
                         'Lo sacamos.
-                        If UserList(MapData(mapa, .Pos.X, .Pos.Y).Userindex).flags.UserLogged Then
-                            Call FinComerciarUsu(MapData(mapa, .Pos.X, .Pos.Y).Userindex)
-                            Call WriteErrorMsg(MapData(mapa, .Pos.X, .Pos.Y).Userindex, "Alguien se ha conectado donde te encontrabas, por favor reconectate...")
-                            Call FlushBuffer(MapData(mapa, .Pos.X, .Pos.Y).Userindex)
+                        If UserList(MapData(Mapa, .Pos.X, .Pos.Y).Userindex).flags.UserLogged Then
+                            Call FinComerciarUsu(MapData(Mapa, .Pos.X, .Pos.Y).Userindex)
+                            Call WriteErrorMsg(MapData(Mapa, .Pos.X, .Pos.Y).Userindex, "Alguien se ha conectado donde te encontrabas, por favor reconectate...")
+                            Call FlushBuffer(MapData(Mapa, .Pos.X, .Pos.Y).Userindex)
 
                         End If
 
                     End If
                 
-                    Call CloseSocket(MapData(mapa, .Pos.X, .Pos.Y).Userindex)
+                    Call CloseSocket(MapData(Mapa, .Pos.X, .Pos.Y).Userindex)
 
                 End If
 
@@ -1737,7 +1356,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
         .showName = True 'Por default los nombres son visibles
     
         'If in the water, and has a boat, equip it!
-        If .Invent.BarcoObjIndex > 0 And (HayAgua(mapa, .Pos.X, .Pos.Y) Or BodyIsBoat(.Char.body)) Then
+        If .Invent.BarcoObjIndex > 0 And (HayAgua(Mapa, .Pos.X, .Pos.Y) Or BodyIsBoat(.Char.body)) Then
 
             .Char.Head = 0
 
@@ -1927,7 +1546,7 @@ Sub ConnectUser(ByVal Userindex As Integer, _
         'el repositorio para hacer funcionar esto, es este: https://github.com/ao-libre/ao-api-server
         'Si no tienen interes en usarlo pueden desactivarlo en el Server.ini
         If ConexionAPI Then
-            Call ApiEndpointSendUserConnectedMessageDiscord(Name, .desc, criminal(Userindex), ListaClases(.clase))
+            Call ApiEndpointSendUserConnectedMessageDiscord(Name, .Desc, criminal(Userindex), ListaClases(.Clase))
         End If
 
         n = FreeFile
@@ -2081,13 +1700,13 @@ Sub ResetBasicUserInfo(ByVal Userindex As Integer)
         .Name = vbNullString
         .ID = 0
         .AccountHash = vbNullString
-        .desc = vbNullString
+        .Desc = vbNullString
         .DescRM = vbNullString
         .Pos.Map = 0
         .Pos.X = 0
         .Pos.Y = 0
         .IP = vbNullString
-        .clase = 0
+        .Clase = 0
         .Email = vbNullString
         .Genero = 0
         .Hogar = 0
@@ -2499,28 +2118,17 @@ Sub ReloadSokcet()
 
     On Error GoTo ErrHandler
 
-    #If UsarQueSocket = 1 Then
-
-        Call LogApiSock("ReloadSokcet() " & NumUsers & " " & LastUser & " " & MaxUsers)
+    Call LogApiSock("ReloadSokcet() " & NumUsers & " " & LastUser & " " & MaxUsers)
     
-        If NumUsers <= 0 Then
-            Call WSApiReiniciarSockets
-        Else
-
-            '       Call apiclosesocket(SockListen)
-            '       SockListen = ListenForConnect(Puerto, hWndMsg, "")
-        End If
-
-    #ElseIf UsarQueSocket = 0 Then
-
-        frmMain.Socket1.Cleanup
-        Call ConfigListeningSocket(frmMain.Socket1, Puerto)
-    
-    #ElseIf UsarQueSocket = 2 Then
-
-    #End If
+    If NumUsers <= 0 Then
+        Call WSApiReiniciarSockets
+    Else
+        'Call apiclosesocket(SockListen)
+        'SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
+    End If
 
     Exit Sub
+    
 ErrHandler:
     Call LogError("Error en CheckSocketState " & Err.Number & ": " & Err.description)
 

--- a/Codigo/frmServidor.frm
+++ b/Codigo/frmServidor.frm
@@ -309,16 +309,8 @@ End Sub
 
 Private Sub Form_Load()
 
-    #If UsarQueSocket = 1 Then
-        cmdResetSockets.Visible = True
-        cmdResetListen.Visible = True
-    #ElseIf UsarQueSocket = 0 Then
-        cmdResetSockets.Visible = False
-        cmdResetListen.Visible = False
-    #ElseIf UsarQueSocket = 2 Then
-        cmdResetSockets.Visible = True
-        cmdResetListen.Visible = False
-    #End If
+    cmdResetSockets.Visible = True
+    cmdResetListen.Visible = True
     
     'Listamos el contenido de la carpeta Dats
     Dim sFilename As String
@@ -386,17 +378,9 @@ Private Sub cmdLoadWorldBackup_Click()
     If FileExist(App.Path & "\logs\Resurrecciones.log", vbNormal) Then Kill App.Path & "\logs\Resurrecciones.log"
     If FileExist(App.Path & "\logs\Teleports.Log", vbNormal) Then Kill App.Path & "\logs\Teleports.Log"
 
-    #If UsarQueSocket = 1 Then
-        Call apiclosesocket(SockListen)
-    #ElseIf UsarQueSocket = 0 Then
-        frmMain.Socket1.Cleanup
-        frmMain.Socket2(0).Cleanup
-    #ElseIf UsarQueSocket = 2 Then
-        frmMain.Serv.Detener
-    #End If
+    Call apiclosesocket(SockListen)
 
     Dim LoopC As Integer
-    
     For LoopC = 1 To MaxUsers
         Call CloseSocket(LoopC)
     Next
@@ -411,27 +395,7 @@ Private Sub cmdLoadWorldBackup_Click()
     Call CargarBackUp
     Call LoadOBJData
 
-    #If UsarQueSocket = 1 Then
-        SockListen = ListenForConnect(Puerto, hWndMsg, "")
-
-    #ElseIf UsarQueSocket = 0 Then
-        frmMain.Socket1.AddressFamily = AF_INET
-        frmMain.Socket1.Protocol = IPPROTO_IP
-        frmMain.Socket1.SocketType = SOCK_STREAM
-        frmMain.Socket1.Binary = False
-        frmMain.Socket1.Blocking = False
-        frmMain.Socket1.BufferSize = 1024
-    
-        frmMain.Socket2(0).AddressFamily = AF_INET
-        frmMain.Socket2(0).Protocol = IPPROTO_IP
-        frmMain.Socket2(0).SocketType = SOCK_STREAM
-        frmMain.Socket2(0).Blocking = False
-        frmMain.Socket2(0).BufferSize = 2048
-    
-        'Escucha
-        frmMain.Socket1.LocalPort = Puerto
-        frmMain.Socket1.listen
-    #End If
+    SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
     If frmMain.Visible Then frmMain.txtStatus.Text = Date & " " & time & " - Reiniciando Terminado. Escuchando conexiones entrantes ..."
 End Sub
@@ -466,47 +430,19 @@ End Sub
 
 Private Sub cmdResetListen_Click()
 
-    #If UsarQueSocket = 1 Then
-
-        'Cierra el socket de escucha
-        If SockListen >= 0 Then Call apiclosesocket(SockListen)
+    'Cierra el socket de escucha
+    If SockListen >= 0 Then Call apiclosesocket(SockListen)
     
-        'Inicia el socket de escucha
-        SockListen = ListenForConnect(Puerto, hWndMsg, "")
-    #End If
+    'Inicia el socket de escucha
+    SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
 End Sub
 
 Private Sub cmdResetSockets_Click()
 
-    #If UsarQueSocket = 1 Then
-
-        If MsgBox("Esta seguro que desea reiniciar los sockets? Se cerraran todas las conexiones activas.", vbYesNo, "Reiniciar Sockets") = vbYes Then
-            Call WSApiReiniciarSockets
-
-        End If
-
-    #ElseIf UsarQueSocket = 2 Then
-
-        Dim LoopC As Integer
-    
-        If MsgBox("Esta seguro que desea reiniciar los sockets? Se cerraran todas las conexiones activas.", vbYesNo, "Reiniciar Sockets") = vbYes Then
-
-            For LoopC = 1 To MaxUsers
-
-                If UserList(LoopC).ConnID <> -1 And UserList(LoopC).ConnIDValida Then
-                    Call CloseSocket(LoopC)
-
-                End If
-
-            Next LoopC
-        
-            Call frmMain.Serv.Detener
-            Call frmMain.Serv.Iniciar(Puerto)
-
-        End If
-
-    #End If
+    If MsgBox("Esta seguro que desea reiniciar los sockets? Se cerraran todas las conexiones activas.", vbYesNo, "Reiniciar Sockets") = vbYes Then
+        Call WSApiReiniciarSockets
+    End If
 
 End Sub
 
@@ -520,11 +456,8 @@ Private Sub cmdUnbanAll_Click()
     On Error Resume Next
 
     Dim Fn       As String
-
     Dim cad$
-
     Dim n        As Integer, K As Integer
-    
     Dim sENtrada As String
     
     sENtrada = InputBox("Escribe ""estoy DE acuerdo"" entre comillas y con distincion de mayusculas minusculas para desbanear a todos los personajes.", "UnBan", "hola")

--- a/Codigo/wskapiAO.bas
+++ b/Codigo/wskapiAO.bas
@@ -24,708 +24,639 @@ Option Explicit
 ' Modulo para manejar Winsock
 '
 
-#If UsarQueSocket = 1 Then
+'Si la variable esta en TRUE , al iniciar el WsApi se crea
+'una ventana LABEL para recibir los mensajes. Al detenerlo,
+'se destruye.
+'Si es FALSE, los mensajes se envian al form frmMain (o el
+'que sea).
+#Const WSAPI_CREAR_LABEL = True
 
-    'Si la variable esta en TRUE , al iniciar el WsApi se crea
-    'una ventana LABEL para recibir los mensajes. Al detenerlo,
-    'se destruye.
-    'Si es FALSE, los mensajes se envian al form frmMain (o el
-    'que sea).
-    #Const WSAPI_CREAR_LABEL = True
+Private Const SD_BOTH As Long = &H2
 
-    Private Const SD_BOTH As Long = &H2
+Public Declare Sub Sleep Lib "kernel32" (ByVal dwMilliseconds As Long)
 
-    Public Declare Sub Sleep Lib "kernel32" (ByVal dwMilliseconds As Long)
+Public Declare Function GetWindowLong Lib "user32" Alias "GetWindowLongA" (ByVal hWnd As Long, ByVal nIndex As Long) As Long
+Public Declare Function SetWindowLong Lib "user32" Alias "SetWindowLongA" (ByVal hWnd As Long, ByVal nIndex As Long, ByVal dwNewLong As Long) As Long
+Public Declare Function CallWindowProc Lib "user32" Alias "CallWindowProcA" (ByVal lpPrevWndFunc As Long, ByVal hWnd As Long, ByVal msg As Long, ByVal wParam As Long, ByVal lParam As Long) As Long
+Private Declare Function CreateWindowEx Lib "user32" Alias "CreateWindowExA" (ByVal dwExStyle As Long, ByVal lpClassName As String, ByVal lpWindowName As String, ByVal dwStyle As Long, ByVal X As Long, ByVal Y As Long, ByVal nWidth As Long, ByVal nHeight As Long, ByVal hwndParent As Long, ByVal hMenu As Long, ByVal hInstance As Long, lpParam As Any) As Long
+Private Declare Function DestroyWindow Lib "user32" (ByVal hWnd As Long) As Long
 
-    Public Declare Function GetWindowLong _
-                   Lib "user32" _
-                   Alias "GetWindowLongA" (ByVal hWnd As Long, _
-                                           ByVal nIndex As Long) As Long
+Private Const WS_CHILD = &H40000000
 
-    Public Declare Function SetWindowLong _
-                   Lib "user32" _
-                   Alias "SetWindowLongA" (ByVal hWnd As Long, _
-                                           ByVal nIndex As Long, _
-                                           ByVal dwNewLong As Long) As Long
+Public Const GWL_WNDPROC = (-4)
 
-    Public Declare Function CallWindowProc _
-                   Lib "user32" _
-                   Alias "CallWindowProcA" (ByVal lpPrevWndFunc As Long, _
-                                            ByVal hWnd As Long, _
-                                            ByVal msg As Long, _
-                                            ByVal wParam As Long, _
-                                            ByVal lParam As Long) As Long
+Private Const SIZE_RCVBUF As Long = 8192
+Private Const SIZE_SNDBUF As Long = 8192
 
-    Private Declare Function CreateWindowEx _
-                    Lib "user32" _
-                    Alias "CreateWindowExA" (ByVal dwExStyle As Long, _
-                                             ByVal lpClassName As String, _
-                                             ByVal lpWindowName As String, _
-                                             ByVal dwStyle As Long, _
-                                             ByVal x As Long, _
-                                             ByVal Y As Long, _
-                                             ByVal nWidth As Long, _
-                                             ByVal nHeight As Long, _
-                                             ByVal hwndParent As Long, _
-                                             ByVal hMenu As Long, _
-                                             ByVal hInstance As Long, _
-                                             lpParam As Any) As Long
+''
+'Esto es para agilizar la busqueda del slot a partir de un socket dado,
+'sino, la funcion BuscaSlotSock se nos come todo el uso del CPU.
+'
+' @param Sock sock
+' @param slot slot
+'
+Public Type tSockCache
 
-    Private Declare Function DestroyWindow Lib "user32" (ByVal hWnd As Long) As Long
+    Sock As Long
+    Slot As Long
 
-    Private Const WS_CHILD = &H40000000
+End Type
 
-    Public Const GWL_WNDPROC = (-4)
+Public WSAPISock2Usr  As Collection
 
-    Private Const SIZE_RCVBUF As Long = 8192
+' ====================================================================================
+' ====================================================================================
 
-    Private Const SIZE_SNDBUF As Long = 8192
+Public OldWProc       As Long
 
-    ''
-    'Esto es para agilizar la busqueda del slot a partir de un socket dado,
-    'sino, la funcion BuscaSlotSock se nos come todo el uso del CPU.
-    '
-    ' @param Sock sock
-    ' @param slot slot
-    '
-    Public Type tSockCache
+Public ActualWProc    As Long
 
-        Sock As Long
-        Slot As Long
+Public hWndMsg        As Long
 
-    End Type
+' ====================================================================================
+' ====================================================================================
 
-    Public WSAPISock2Usr As Collection
+Public SockListen     As Long
 
-    ' ====================================================================================
-    ' ====================================================================================
-
-    Public OldWProc      As Long
-
-    Public ActualWProc   As Long
-
-    Public hWndMsg       As Long
-
-    ' ====================================================================================
-    ' ====================================================================================
-
-    Public SockListen       As Long
-    Public LastSockListen   As Long
-
-#End If
+Public LastSockListen As Long
 
 ' ====================================================================================
 ' ====================================================================================
 
 Public Sub IniciaWsApi(ByVal hwndParent As Long)
-    #If UsarQueSocket = 1 Then
 
-        Call LogApiSock("IniciaWsApi")
-        Debug.Print "IniciaWsApi"
+    Call LogApiSock("IniciaWsApi")
+    Debug.Print "IniciaWsApi"
 
-        #If WSAPI_CREAR_LABEL Then
-            hWndMsg = CreateWindowEx(0, "STATIC", "AOMSG", WS_CHILD, 0, 0, 0, 0, hwndParent, 0, App.hInstance, ByVal 0&)
-        #Else
-            hWndMsg = hwndParent
-        #End If 'WSAPI_CREAR_LABEL
+    #If WSAPI_CREAR_LABEL Then
+        hWndMsg = CreateWindowEx(0, "STATIC", "AOMSG", WS_CHILD, 0, 0, 0, 0, hwndParent, 0, App.hInstance, ByVal 0&)
+    #Else
+        hWndMsg = hwndParent
+    #End If 'WSAPI_CREAR_LABEL
 
-        OldWProc = SetWindowLong(hWndMsg, GWL_WNDPROC, AddressOf WndProc)
-        ActualWProc = GetWindowLong(hWndMsg, GWL_WNDPROC)
+    OldWProc = SetWindowLong(hWndMsg, GWL_WNDPROC, AddressOf WndProc)
+    ActualWProc = GetWindowLong(hWndMsg, GWL_WNDPROC)
 
-        Dim desc As String
+    Dim Desc As String
 
-        Call StartWinsock(desc)
-
-    #End If
+    Call StartWinsock(Desc)
 
 End Sub
 
 Public Sub LimpiaWsApi()
-    #If UsarQueSocket = 1 Then
 
-        Call LogApiSock("LimpiaWsApi")
+    Call LogApiSock("LimpiaWsApi")
 
-        If WSAStartedUp Then
-            Call EndWinsock
+    If WSAStartedUp Then
+        Call EndWinsock
+
+    End If
+
+    If OldWProc <> 0 Then
+        SetWindowLong hWndMsg, GWL_WNDPROC, OldWProc
+        OldWProc = 0
+
+    End If
+
+    #If WSAPI_CREAR_LABEL Then
+
+        If hWndMsg <> 0 Then
+            DestroyWindow hWndMsg
 
         End If
-
-        If OldWProc <> 0 Then
-            SetWindowLong hWndMsg, GWL_WNDPROC, OldWProc
-            OldWProc = 0
-
-        End If
-
-        #If WSAPI_CREAR_LABEL Then
-
-            If hWndMsg <> 0 Then
-                DestroyWindow hWndMsg
-
-            End If
-
-        #End If
 
     #End If
 
 End Sub
 
 Public Function BuscaSlotSock(ByVal S As Long) As Long
-    #If UsarQueSocket = 1 Then
 
-        On Error GoTo hayerror
+    On Error GoTo hayerror
     
-        If WSAPISock2Usr.Count <> 0 Then ' GSZAO
-            BuscaSlotSock = WSAPISock2Usr.Item(CStr(S))
-        Else
-            BuscaSlotSock = -1
+    If WSAPISock2Usr.Count <> 0 Then ' GSZAO
+        BuscaSlotSock = WSAPISock2Usr.Item(CStr(S))
+    Else
+        BuscaSlotSock = -1
 
-        End If
+    End If
     
-        Exit Function
+    Exit Function
     
 hayerror:
-        BuscaSlotSock = -1
-    #End If
+    BuscaSlotSock = -1
 
 End Function
 
 Public Sub AgregaSlotSock(ByVal Sock As Long, ByVal Slot As Long)
     Debug.Print "AgregaSockSlot"
-    #If (UsarQueSocket = 1) Then
 
-        If WSAPISock2Usr.Count > MaxUsers Then
-            Call CloseSocket(Slot)
-            Exit Sub
+    If WSAPISock2Usr.Count > MaxUsers Then
+        Call CloseSocket(Slot)
+        Exit Sub
 
-        End If
+    End If
 
-        WSAPISock2Usr.Add CStr(Slot), CStr(Sock)
+    WSAPISock2Usr.Add CStr(Slot), CStr(Sock)
 
-        'Dim Pri As Long, Ult As Long, Med As Long
-        'Dim LoopC As Long
-        '
-        'If WSAPISockChacheCant > 0 Then
-        '    Pri = 1
-        '    Ult = WSAPISockChacheCant
-        '    Med = Int((Pri + Ult) / 2)
-        '
-        '    Do While (Pri <= Ult) And (Ult > 1)
-        '        If Sock < WSAPISockChache(Med).Sock Then
-        '            Ult = Med - 1
-        '        Else
-        '            Pri = Med + 1
-        '        End If
-        '        Med = Int((Pri + Ult) / 2)
-        '    Loop
-        '
-        '    Pri = IIf(Sock < WSAPISockChache(Med).Sock, Med, Med + 1)
-        '    Ult = WSAPISockChacheCant
-        '    For LoopC = Ult To Pri Step -1
-        '        WSAPISockChache(LoopC + 1) = WSAPISockChache(LoopC)
-        '    Next LoopC
-        '    Med = Pri
-        'Else
-        '    Med = 1
-        'End If
-        'WSAPISockChache(Med).Slot = Slot
-        'WSAPISockChache(Med).Sock = Sock
-        'WSAPISockChacheCant = WSAPISockChacheCant + 1
-
-    #End If
+    'Dim Pri As Long, Ult As Long, Med As Long
+    'Dim LoopC As Long
+    '
+    'If WSAPISockChacheCant > 0 Then
+    '    Pri = 1
+    '    Ult = WSAPISockChacheCant
+    '    Med = Int((Pri + Ult) / 2)
+    '
+    '    Do While (Pri <= Ult) And (Ult > 1)
+    '        If Sock < WSAPISockChache(Med).Sock Then
+    '            Ult = Med - 1
+    '        Else
+    '            Pri = Med + 1
+    '        End If
+    '        Med = Int((Pri + Ult) / 2)
+    '    Loop
+    '
+    '    Pri = IIf(Sock < WSAPISockChache(Med).Sock, Med, Med + 1)
+    '    Ult = WSAPISockChacheCant
+    '    For LoopC = Ult To Pri Step -1
+    '        WSAPISockChache(LoopC + 1) = WSAPISockChache(LoopC)
+    '    Next LoopC
+    '    Med = Pri
+    'Else
+    '    Med = 1
+    'End If
+    'WSAPISockChache(Med).Slot = Slot
+    'WSAPISockChache(Med).Sock = Sock
+    'WSAPISockChacheCant = WSAPISockChacheCant + 1
 
 End Sub
 
 Public Sub BorraSlotSock(ByVal Sock As Long)
-    #If (UsarQueSocket = 1) Then
 
-        Dim cant As Long
+    Dim cant As Long
 
-        cant = WSAPISock2Usr.Count
+    cant = WSAPISock2Usr.Count
 
-        On Error Resume Next
+    On Error Resume Next
 
-        WSAPISock2Usr.Remove CStr(Sock)
+    WSAPISock2Usr.Remove CStr(Sock)
 
-        Debug.Print "BorraSockSlot " & cant & " -> " & WSAPISock2Usr.Count
-
-    #End If
+    Debug.Print "BorraSockSlot " & cant & " -> " & WSAPISock2Usr.Count
 
 End Sub
 
 Public Function WndProc(ByVal hWnd As Long, _
-                        ByVal msg As Long, _
-                        ByVal wParam As Long, _
-                        ByVal lParam As Long) As Long
-    #If UsarQueSocket = 1 Then
+   ByVal msg As Long, _
+   ByVal wParam As Long, _
+   ByVal lParam As Long) As Long
 
-        On Error Resume Next
+    On Error Resume Next
 
-        Dim ret      As Long
+    Dim ret      As Long
 
-        Dim Tmp()    As Byte
+    Dim Tmp()    As Byte
 
-        Dim S        As Long
+    Dim S        As Long
 
-        Dim e        As Long
+    Dim e        As Long
 
-        Dim n        As Integer
+    Dim n        As Integer
 
-        Dim UltError As Long
+    Dim UltError As Long
     
-        Select Case msg
+    Select Case msg
 
-            Case 1025
-                S = wParam
-                e = WSAGetSelectEvent(lParam)
+        Case 1025
+            S = wParam
+            e = WSAGetSelectEvent(lParam)
             
-                Select Case e
+            Select Case e
 
-                    Case FD_ACCEPT
+                Case FD_ACCEPT
 
-                        If S = SockListen Then
-                            Call EventoSockAccept(S)
+                    If S = SockListen Then
+                        Call EventoSockAccept(S)
 
-                        End If
+                    End If
                 
-                        '    Case FD_WRITE
-                        '        N = BuscaSlotSock(s)
-                        '        If N < 0 And s <> SockListen Then
-                        '            'Call apiclosesocket(s)
-                        '            call WSApiCloseSocket(s)
-                        '            Exit Function
-                        '        End If
-                        '
+                    '    Case FD_WRITE
+                    '        N = BuscaSlotSock(s)
+                    '        If N < 0 And s <> SockListen Then
+                    '            'Call apiclosesocket(s)
+                    '            call WSApiCloseSocket(s)
+                    '            Exit Function
+                    '        End If
+                    '
             
-                        '        Call IntentarEnviarDatosEncolados(N)
-                        '
-                        '        Dale = UserList(N).ColaSalida.Count > 0
-                        '        Do While Dale
-                        '            Ret = WsApiEnviar(N, UserList(N).ColaSalida.Item(1), False)
-                        '            If Ret <> 0 Then
-                        '                If Ret = WSAEWOULDBLOCK Then
-                        '                    Dale = False
-                        '                Else
-                        '                    'y aca que hacemo' ?? help! i need somebody, help!
-                        '                    Dale = False
-                        '                    Debug.Print "ERROR AL ENVIAR EL DATO DESDE LA COLA " & Ret & ": " & GetWSAErrorString(Ret)
-                        '                End If
-                        '            Else
-                        '            '    Debug.Print "Dato de la cola enviado"
-                        '                UserList(N).ColaSalida.Remove 1
-                        '                Dale = (UserList(N).ColaSalida.Count > 0)
-                        '            End If
-                        '        Loop
+                    '        Call IntentarEnviarDatosEncolados(N)
+                    '
+                    '        Dale = UserList(N).ColaSalida.Count > 0
+                    '        Do While Dale
+                    '            Ret = WsApiEnviar(N, UserList(N).ColaSalida.Item(1), False)
+                    '            If Ret <> 0 Then
+                    '                If Ret = WSAEWOULDBLOCK Then
+                    '                    Dale = False
+                    '                Else
+                    '                    'y aca que hacemo' ?? help! i need somebody, help!
+                    '                    Dale = False
+                    '                    Debug.Print "ERROR AL ENVIAR EL DATO DESDE LA COLA " & Ret & ": " & GetWSAErrorString(Ret)
+                    '                End If
+                    '            Else
+                    '            '    Debug.Print "Dato de la cola enviado"
+                    '                UserList(N).ColaSalida.Remove 1
+                    '                Dale = (UserList(N).ColaSalida.Count > 0)
+                    '            End If
+                    '        Loop
         
-                    Case FD_READ
-                        n = BuscaSlotSock(S)
+                Case FD_READ
+                    n = BuscaSlotSock(S)
 
-                        If n < 0 And S <> SockListen Then
-                            'Call apiclosesocket(s)
-                            Call WSApiCloseSocket(S)
+                    If n < 0 And S <> SockListen Then
+                        'Call apiclosesocket(s)
+                        Call WSApiCloseSocket(S)
+                        Exit Function
+
+                    End If
+                    
+                    'create appropiate sized buffer
+                    ReDim Preserve Tmp(SIZE_RCVBUF - 1) As Byte
+                    
+                    ret = recv(S, Tmp(0), SIZE_RCVBUF, 0)
+
+                    ' Comparo por = 0 ya que esto es cuando se cierra
+                    ' "gracefully". (mas abajo)
+                    If ret < 0 Then
+                        UltError = Err.LastDllError
+
+                        If UltError = WSAEMSGSIZE Then
+                            Debug.Print "WSAEMSGSIZE"
+                            ret = SIZE_RCVBUF
+                        Else
+                            Debug.Print "Error en Recv: " & GetWSAErrorString(UltError)
+                            Call LogApiSock("Error en Recv: N=" & n & " S=" & S & " Str=" & GetWSAErrorString(UltError))
+                            
+                            'no hay q llamar a CloseSocket() directamente,
+                            'ya q pueden abusar de algun error para
+                            'desconectarse sin los 10segs. CREEME.
+                            Call CloseSocketSL(n)
+                            Call Cerrar_Usuario(n)
                             Exit Function
 
                         End If
+
+                    ElseIf ret = 0 Then
+                        Call CloseSocketSL(n)
+                        Call Cerrar_Usuario(n)
+
+                    End If
                     
-                        'create appropiate sized buffer
-                        ReDim Preserve Tmp(SIZE_RCVBUF - 1) As Byte
+                    ReDim Preserve Tmp(ret - 1) As Byte
                     
-                        ret = recv(S, Tmp(0), SIZE_RCVBUF, 0)
-
-                        ' Comparo por = 0 ya que esto es cuando se cierra
-                        ' "gracefully". (mas abajo)
-                        If ret < 0 Then
-                            UltError = Err.LastDllError
-
-                            If UltError = WSAEMSGSIZE Then
-                                Debug.Print "WSAEMSGSIZE"
-                                ret = SIZE_RCVBUF
-                            Else
-                                Debug.Print "Error en Recv: " & GetWSAErrorString(UltError)
-                                Call LogApiSock("Error en Recv: N=" & n & " S=" & S & " Str=" & GetWSAErrorString(UltError))
-                            
-                                'no hay q llamar a CloseSocket() directamente,
-                                'ya q pueden abusar de algun error para
-                                'desconectarse sin los 10segs. CREEME.
-                                Call CloseSocketSL(n)
-                                Call Cerrar_Usuario(n)
-                                Exit Function
-
-                            End If
-
-                        ElseIf ret = 0 Then
-                            Call CloseSocketSL(n)
-                            Call Cerrar_Usuario(n)
-
-                        End If
-                    
-                        ReDim Preserve Tmp(ret - 1) As Byte
-                    
-                        Call EventoSockRead(n, Tmp)
+                    Call EventoSockRead(n, Tmp)
                 
-                    Case FD_CLOSE
-                        n = BuscaSlotSock(S)
+                Case FD_CLOSE
+                    n = BuscaSlotSock(S)
 
-                        If S <> SockListen Then Call apiclosesocket(S)
+                    If S <> SockListen Then Call apiclosesocket(S)
                     
-                        If n > 0 Then
-                            Call BorraSlotSock(S)
-                            UserList(n).ConnID = -1
-                            UserList(n).ConnIDValida = False
-                            Call EventoSockClose(n)
+                    If n > 0 Then
+                        Call BorraSlotSock(S)
+                        UserList(n).ConnID = -1
+                        UserList(n).ConnIDValida = False
+                        Call EventoSockClose(n)
 
-                        End If
+                    End If
 
-                End Select
+            End Select
         
-            Case Else
-                WndProc = CallWindowProc(OldWProc, hWnd, msg, wParam, lParam)
+        Case Else
+            WndProc = CallWindowProc(OldWProc, hWnd, msg, wParam, lParam)
 
-        End Select
-
-    #End If
+    End Select
 
 End Function
 
 'Retorna 0 cuando se envio o se metio en la cola,
 'retorna <> 0 cuando no se pudo enviar o no se pudo meter en la cola
 Public Function WsApiEnviar(ByVal Slot As Integer, ByRef str As String) As Long
-    #If UsarQueSocket = 1 Then
 
-        Dim ret     As String
+    Dim ret     As String
 
-        Dim Retorno As Long
+    Dim Retorno As Long
 
-        Dim data()  As Byte
+    Dim data()  As Byte
     
-        ReDim Preserve data(Len(str) - 1) As Byte
+    ReDim Preserve data(Len(str) - 1) As Byte
 
-        data = StrConv(str, vbFromUnicode)
+    data = StrConv(str, vbFromUnicode)
     
-        Retorno = 0
+    Retorno = 0
     
-        If UserList(Slot).ConnID <> -1 And UserList(Slot).ConnIDValida Then
-            ret = send(ByVal UserList(Slot).ConnID, data(0), ByVal UBound(data()) + 1, ByVal 0)
+    If UserList(Slot).ConnID <> -1 And UserList(Slot).ConnIDValida Then
+        ret = send(ByVal UserList(Slot).ConnID, data(0), ByVal UBound(data()) + 1, ByVal 0)
 
-            If ret < 0 Then
-                ret = Err.LastDllError
+        If ret < 0 Then
+            ret = Err.LastDllError
 
-                If ret = WSAEWOULDBLOCK Then
+            If ret = WSAEWOULDBLOCK Then
                 
-                    ' WSAEWOULDBLOCK, put the data again in the outgoingData Buffer
-                    Call UserList(Slot).outgoingData.WriteASCIIStringFixed(str)
-
-                End If
-
-            End If
-
-        ElseIf UserList(Slot).ConnID <> -1 And Not UserList(Slot).ConnIDValida Then
-
-            If Not UserList(Slot).Counters.Saliendo Then
-                Retorno = -1
+                ' WSAEWOULDBLOCK, put the data again in the outgoingData Buffer
+                Call UserList(Slot).outgoingData.WriteASCIIStringFixed(str)
 
             End If
 
         End If
+
+    ElseIf UserList(Slot).ConnID <> -1 And Not UserList(Slot).ConnIDValida Then
+
+        If Not UserList(Slot).Counters.Saliendo Then
+            Retorno = -1
+
+        End If
+
+    End If
     
-        WsApiEnviar = Retorno
-    #End If
+    WsApiEnviar = Retorno
 
 End Function
 
 Public Sub LogApiSock(ByVal str As String)
-    #If (UsarQueSocket = 1) Then
 
-        On Error GoTo errHandler
+    On Error GoTo ErrHandler
 
-        Dim nfile As Integer
+    Dim nfile As Integer
 
-        nfile = FreeFile ' obtenemos un canal
-        Open App.Path & "\logs\wsapi.log" For Append Shared As #nfile
-        Print #nfile, Date & " " & time & " " & str
-        Close #nfile
+    nfile = FreeFile ' obtenemos un canal
+    Open App.Path & "\logs\wsapi.log" For Append Shared As #nfile
+    Print #nfile, Date & " " & time & " " & str
+    Close #nfile
 
-        Exit Sub
+    Exit Sub
 
-errHandler:
-
-    #End If
+ErrHandler:
 
 End Sub
 
 Public Sub EventoSockAccept(ByVal SockID As Long)
-    #If UsarQueSocket = 1 Then
-        '==========================================================
-        'USO DE LA API DE WINSOCK
-        '========================
+
+    '========================
+    'USO DE LA API DE WINSOCK
+    '========================
     
-        Dim NewIndex  As Integer
+    Dim NewIndex  As Integer
 
-        Dim ret       As Long
+    Dim ret       As Long
 
-        Dim Tam       As Long, sa As sockaddr
+    Dim Tam       As Long, sa As sockaddr
 
-        Dim NuevoSock As Long
+    Dim NuevoSock As Long
 
-        Dim i         As Long
+    Dim i         As Long
 
-        Dim str       As String
+    Dim str       As String
 
-        Dim data()    As Byte
+    Dim data()    As Byte
     
-        Tam = sockaddr_size
+    Tam = sockaddr_size
     
-        '=============================================
-        'SockID es en este caso es el socket de escucha,
-        'a diferencia de socketwrench que es el nuevo
-        'socket de la nueva conn
+    '=============================================
+    'SockID es en este caso es el socket de escucha,
+    'a diferencia de socketwrench que es el nuevo
+    'socket de la nueva conn
     
-        'Modificado por Maraxus
-        'ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 0)
-        ret = accept(SockID, sa, Tam)
+    'Modificado por Maraxus
+    'ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 0)
+    ret = accept(SockID, sa, Tam)
 
-        If ret = INVALID_SOCKET Then
-            i = Err.LastDllError
-            Call LogCriticEvent("Error en Accept() API " & i & ": " & GetWSAErrorString(i))
-            Exit Sub
+    If ret = INVALID_SOCKET Then
+        i = Err.LastDllError
+        Call LogCriticEvent("Error en Accept() API " & i & ": " & GetWSAErrorString(i))
+        Exit Sub
 
-        End If
+    End If
 
-        'If ret = INVALID_SOCKET Then
-        '    If Err.LastDllError = 11002 Then
-        '        ' We couldn't decide if to accept or reject the connection
-        '        'Force reject so we can get it out of the queue
-        '        ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 1)
-        '        Call LogCriticEvent("Error en WSAAccept() API 11002: No se pudo decidir si aceptar o rechazar la conexion.")
-        '    Else
-        '        i = Err.LastDllError
-        '        Call LogCriticEvent("Error en WSAAccept() API " & i & ": " & GetWSAErrorString(i))
-        '        Exit Sub
-        '    End If
-        'End If
+    'If ret = INVALID_SOCKET Then
+    '    If Err.LastDllError = 11002 Then
+    '        ' We couldn't decide if to accept or reject the connection
+    '        'Force reject so we can get it out of the queue
+    '        ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 1)
+    '        Call LogCriticEvent("Error en WSAAccept() API 11002: No se pudo decidir si aceptar o rechazar la conexion.")
+    '    Else
+    '        i = Err.LastDllError
+    '        Call LogCriticEvent("Error en WSAAccept() API " & i & ": " & GetWSAErrorString(i))
+    '        Exit Sub
+    '    End If
+    'End If
 
-        NuevoSock = ret
+    NuevoSock = ret
     
-        If setsockopt(NuevoSock, SOL_SOCKET, SO_LINGER, 0, 4) <> 0 Then
-            i = Err.LastDllError
-            Call LogCriticEvent("Error al setear lingers." & i & ": " & GetWSAErrorString(i))
+    If setsockopt(NuevoSock, SOL_SOCKET, SO_LINGER, 0, 4) <> 0 Then
+        i = Err.LastDllError
+        Call LogCriticEvent("Error al setear lingers." & i & ": " & GetWSAErrorString(i))
 
-        End If
+    End If
     
-        If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
-            Call WSApiCloseSocket(NuevoSock)
-            Exit Sub
+    If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
+        Call WSApiCloseSocket(NuevoSock)
+        Exit Sub
 
-        End If
+    End If
     
-        If SecurityIp.IPSecuritySuperaLimiteConexiones(sa.sin_addr) Then
-            str = Protocol.PrepareMessageErrorMsg("Limite de conexiones para su IP alcanzado.")
+    If SecurityIp.IPSecuritySuperaLimiteConexiones(sa.sin_addr) Then
+        str = Protocol.PrepareMessageErrorMsg("Limite de conexiones para su IP alcanzado.")
         
-            ReDim Preserve data(Len(str) - 1) As Byte
+        ReDim Preserve data(Len(str) - 1) As Byte
         
-            data = StrConv(str, vbFromUnicode)
+        data = StrConv(str, vbFromUnicode)
         
-            Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
-            Call WSApiCloseSocket(NuevoSock)
-            Exit Sub
+        Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
+        Call WSApiCloseSocket(NuevoSock)
+        Exit Sub
 
-        End If
+    End If
     
-        'Seteamos el tamano del buffer de entrada
-        If setsockopt(NuevoSock, SOL_SOCKET, SO_RCVBUFFER, SIZE_RCVBUF, 4) <> 0 Then
-            i = Err.LastDllError
-            Call LogCriticEvent("Error al setear el tamano del buffer de entrada " & i & ": " & GetWSAErrorString(i))
+    'Seteamos el tamano del buffer de entrada
+    If setsockopt(NuevoSock, SOL_SOCKET, SO_RCVBUFFER, SIZE_RCVBUF, 4) <> 0 Then
+        i = Err.LastDllError
+        Call LogCriticEvent("Error al setear el tamano del buffer de entrada " & i & ": " & GetWSAErrorString(i))
 
-        End If
+    End If
 
-        'Seteamos el tamano del buffer de salida
-        If setsockopt(NuevoSock, SOL_SOCKET, SO_SNDBUFFER, SIZE_SNDBUF, 4) <> 0 Then
-            i = Err.LastDllError
-            Call LogCriticEvent("Error al setear el tamano del buffer de salida " & i & ": " & GetWSAErrorString(i))
+    'Seteamos el tamano del buffer de salida
+    If setsockopt(NuevoSock, SOL_SOCKET, SO_SNDBUFFER, SIZE_SNDBUF, 4) <> 0 Then
+        i = Err.LastDllError
+        Call LogCriticEvent("Error al setear el tamano del buffer de salida " & i & ": " & GetWSAErrorString(i))
 
-        End If
+    End If
     
-        '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-        '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-        '   BIENVENIDO AL SERVIDOR!!!!!!!!
-        '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-        '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+    '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+    '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+    '   BIENVENIDO AL SERVIDOR!!!!!!!!
+    '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+    '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
     
-        'Mariano: Baje la busqueda de slot abajo de CondicionSocket y limite x ip
-        NewIndex = NextOpenUser ' Nuevo indice
+    'Mariano: Baje la busqueda de slot abajo de CondicionSocket y limite x ip
+    NewIndex = NextOpenUser ' Nuevo indice
     
-        If NewIndex <= MaxUsers Then
+    If NewIndex <= MaxUsers Then
         
-            'Make sure both outgoing and incoming data buffers are clean
-            Call UserList(NewIndex).incomingData.ReadASCIIStringFixed(UserList(NewIndex).incomingData.Length)
-            Call UserList(NewIndex).outgoingData.ReadASCIIStringFixed(UserList(NewIndex).outgoingData.Length)
+        'Make sure both outgoing and incoming data buffers are clean
+        Call UserList(NewIndex).incomingData.ReadASCIIStringFixed(UserList(NewIndex).incomingData.Length)
+        Call UserList(NewIndex).outgoingData.ReadASCIIStringFixed(UserList(NewIndex).outgoingData.Length)
         
-            UserList(NewIndex).ip = GetAscIP(sa.sin_addr)
+        UserList(NewIndex).IP = GetAscIP(sa.sin_addr)
 
-            'Busca si esta banneada la ip
-            For i = 1 To BanIps.Count
+        'Busca si esta banneada la ip
+        For i = 1 To BanIps.Count
 
-                If BanIps.Item(i) = UserList(NewIndex).ip Then
-                    'Call apiclosesocket(NuevoSock)
-                    Call WriteErrorMsg(NewIndex, "Su IP se encuentra bloqueada en este servidor.")
-                    Call FlushBuffer(NewIndex)
-                    Call SecurityIp.IpRestarConexion(sa.sin_addr)
-                    Call WSApiCloseSocket(NuevoSock)
-                    Exit Sub
-
-                End If
-
-            Next i
-        
-            If NewIndex > LastUser Then LastUser = NewIndex
-        
-            UserList(NewIndex).ConnID = NuevoSock
-            UserList(NewIndex).ConnIDValida = True
-        
-            Call AgregaSlotSock(NuevoSock, NewIndex)
-        Else
-            str = Protocol.PrepareMessageErrorMsg("El servidor se encuentra lleno en este momento. Disculpe las molestias ocasionadas.")
-        
-            ReDim Preserve data(Len(str) - 1) As Byte
-        
-            data = StrConv(str, vbFromUnicode)
-        
-            Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
-            Call WSApiCloseSocket(NuevoSock)
-
-        End If
-    
-    #End If
-
-End Sub
-
-Public Sub EventoSockRead(ByVal Slot As Integer, ByRef Datos() As Byte)
-    #If UsarQueSocket = 1 Then
-
-        With UserList(Slot)
-    
-            Call .incomingData.WriteBlock(Datos)
-    
-            If .ConnID <> -1 Then
-                Do While HandleIncomingData(Slot) = True
-                Loop
-            Else
+            If BanIps.Item(i) = UserList(NewIndex).IP Then
+                'Call apiclosesocket(NuevoSock)
+                Call WriteErrorMsg(NewIndex, "Su IP se encuentra bloqueada en este servidor.")
+                Call FlushBuffer(NewIndex)
+                Call SecurityIp.IpRestarConexion(sa.sin_addr)
+                Call WSApiCloseSocket(NuevoSock)
                 Exit Sub
 
             End If
 
-        End With
+        Next i
+        
+        If NewIndex > LastUser Then LastUser = NewIndex
+        
+        UserList(NewIndex).ConnID = NuevoSock
+        UserList(NewIndex).ConnIDValida = True
+        
+        Call AgregaSlotSock(NuevoSock, NewIndex)
+    Else
+        str = Protocol.PrepareMessageErrorMsg("El servidor se encuentra lleno en este momento. Disculpe las molestias ocasionadas.")
+        
+        ReDim Preserve data(Len(str) - 1) As Byte
+        
+        data = StrConv(str, vbFromUnicode)
+        
+        Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
+        Call WSApiCloseSocket(NuevoSock)
 
-    #End If
+    End If
+
+End Sub
+
+Public Sub EventoSockRead(ByVal Slot As Integer, ByRef Datos() As Byte)
+
+    With UserList(Slot)
+    
+        Call .incomingData.WriteBlock(Datos)
+    
+        If .ConnID <> -1 Then
+
+            Do While HandleIncomingData(Slot) = True
+            Loop
+        Else
+            Exit Sub
+
+        End If
+
+    End With
 
 End Sub
 
 Public Sub EventoSockClose(ByVal Slot As Integer)
-    #If UsarQueSocket = 1 Then
     
-        'maTih.-  Nuevo centinela.
-        If UserList(Slot).CentinelaUsuario.centinelaIndex <> 0 Then
-            Call modCentinela.UsuarioInActivo(Slot)
+    'maTih.-  Nuevo centinela.
+    If UserList(Slot).CentinelaUsuario.centinelaIndex <> 0 Then
+        Call modCentinela.UsuarioInActivo(Slot)
 
-        End If
+    End If
 
-        If UserList(Slot).flags.UserLogged Then
-            Call CloseSocketSL(Slot)
-            Call Cerrar_Usuario(Slot)
-        Else
-            Call CloseSocket(Slot)
+    If UserList(Slot).flags.UserLogged Then
+        Call CloseSocketSL(Slot)
+        Call Cerrar_Usuario(Slot)
+    Else
+        Call CloseSocket(Slot)
 
-        End If
-
-    #End If
+    End If
 
 End Sub
 
 Public Sub WSApiReiniciarSockets()
-    #If UsarQueSocket = 1 Then
 
-        Dim i As Long
+    Dim i As Long
 
-        'Cierra el socket de escucha
-        If SockListen >= 0 Then Call apiclosesocket(SockListen)
+    'Cierra el socket de escucha
+    If SockListen >= 0 Then Call apiclosesocket(SockListen)
     
-        'Cierra todas las conexiones
-        For i = 1 To MaxUsers
+    'Cierra todas las conexiones
+    For i = 1 To MaxUsers
 
-            If UserList(i).ConnID <> -1 And UserList(i).ConnIDValida Then
-                Call CloseSocket(i)
+        If UserList(i).ConnID <> -1 And UserList(i).ConnIDValida Then
+            Call CloseSocket(i)
 
-            End If
+        End If
         
-            'Call ResetUserSlot(i)
-        Next i
+        'Call ResetUserSlot(i)
+    Next i
     
-        For i = 1 To MaxUsers
-            Set UserList(i).incomingData = Nothing
-            Set UserList(i).outgoingData = Nothing
-        Next i
+    For i = 1 To MaxUsers
+        Set UserList(i).incomingData = Nothing
+        Set UserList(i).outgoingData = Nothing
+    Next i
     
-        ' No 'ta el PRESERVE :p
-        ReDim UserList(1 To MaxUsers)
+    ' No 'ta el PRESERVE :p
+    ReDim UserList(1 To MaxUsers)
 
-        For i = 1 To MaxUsers
-            UserList(i).ConnID = -1
-            UserList(i).ConnIDValida = False
+    For i = 1 To MaxUsers
+        UserList(i).ConnID = -1
+        UserList(i).ConnIDValida = False
         
-            Set UserList(i).incomingData = New clsByteQueue
-            Set UserList(i).outgoingData = New clsByteQueue
-        Next i
+        Set UserList(i).incomingData = New clsByteQueue
+        Set UserList(i).outgoingData = New clsByteQueue
+    Next i
     
-        LastUser = 1
-        NumUsers = 0
+    LastUser = 1
+    NumUsers = 0
     
-        Call LimpiaWsApi
-        Call Sleep(100)
-        Call IniciaWsApi(frmMain.hWnd)
-        SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
-
-    #End If
+    Call LimpiaWsApi
+    Call Sleep(100)
+    Call IniciaWsApi(frmMain.hWnd)
+    SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
 End Sub
 
 Public Sub WSApiCloseSocket(ByVal Socket As Long)
-    #If UsarQueSocket = 1 Then
-        Call WSAAsyncSelect(Socket, hWndMsg, ByVal 1025, ByVal (FD_CLOSE))
-        Call ShutDown(Socket, SD_BOTH)
-    #End If
+
+    Call WSAAsyncSelect(Socket, hWndMsg, ByVal 1025, ByVal (FD_CLOSE))
+    Call ShutDown(Socket, SD_BOTH)
 
 End Sub
 
 Public Function CondicionSocket(ByRef lpCallerId As WSABUF, _
-                                ByRef lpCallerData As WSABUF, _
-                                ByRef lpSQOS As FLOWSPEC, _
-                                ByVal Reserved As Long, _
-                                ByRef lpCalleeId As WSABUF, _
-                                ByRef lpCalleeData As WSABUF, _
-                                ByRef Group As Long, _
-                                ByVal dwCallbackData As Long) As Long
-    #If UsarQueSocket = 1 Then
+   ByRef lpCallerData As WSABUF, _
+   ByRef lpSQOS As FLOWSPEC, _
+   ByVal Reserved As Long, _
+   ByRef lpCalleeId As WSABUF, _
+   ByRef lpCalleeData As WSABUF, _
+   ByRef Group As Long, _
+   ByVal dwCallbackData As Long) As Long
 
-        Dim sa As sockaddr
+    Dim sa As sockaddr
     
-        'Check if we were requested to force reject
+    'Check if we were requested to force reject
 
-        If dwCallbackData = 1 Then
-            CondicionSocket = CF_REJECT
-            Exit Function
+    If dwCallbackData = 1 Then
+        CondicionSocket = CF_REJECT
+        Exit Function
 
-        End If
+    End If
     
-        'Get the address
+    'Get the address
 
-        CopyMemory sa, ByVal lpCallerId.lpBuffer, lpCallerId.dwBufferLen
+    CopyMemory sa, ByVal lpCallerId.lpBuffer, lpCallerId.dwBufferLen
     
-        If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
-            CondicionSocket = CF_REJECT
-            Exit Function
+    If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
+        CondicionSocket = CF_REJECT
+        Exit Function
 
-        End If
+    End If
 
-        CondicionSocket = CF_ACCEPT 'En realdiad es al pedo, porque CondicionSocket se inicializa a 0, pero asi es mas claro....
-    #End If
+    CondicionSocket = CF_ACCEPT 'En realdiad es al pedo, porque CondicionSocket se inicializa a 0, pero asi es mas claro....
 
 End Function

--- a/Codigo/wskapiAO.bas
+++ b/Codigo/wskapiAO.bas
@@ -56,28 +56,21 @@ Private Const SIZE_SNDBUF As Long = 8192
 ' @param slot slot
 '
 Public Type tSockCache
-
     Sock As Long
     Slot As Long
-
 End Type
 
 Public WSAPISock2Usr  As Collection
 
 ' ====================================================================================
 ' ====================================================================================
-
 Public OldWProc       As Long
-
 Public ActualWProc    As Long
-
 Public hWndMsg        As Long
 
 ' ====================================================================================
 ' ====================================================================================
-
 Public SockListen     As Long
-
 Public LastSockListen As Long
 
 ' ====================================================================================
@@ -85,8 +78,8 @@ Public LastSockListen As Long
 
 Public Sub IniciaWsApi(ByVal hwndParent As Long)
 
-    Call LogApiSock("IniciaWsApi")
-    Debug.Print "IniciaWsApi"
+    Call LogApiSock("Iniciando Winsock2 API...")
+    Debug.Print "Iniciando Winsock2 API..."
 
     #If WSAPI_CREAR_LABEL Then
         hWndMsg = CreateWindowEx(0, "STATIC", "AOMSG", WS_CHILD, 0, 0, 0, 0, hwndParent, 0, App.hInstance, ByVal 0&)
@@ -105,24 +98,21 @@ End Sub
 
 Public Sub LimpiaWsApi()
 
-    Call LogApiSock("LimpiaWsApi")
+    Call LogApiSock("Limpiando informacion de Winsock2 API...")
 
     If WSAStartedUp Then
         Call EndWinsock
-
     End If
 
     If OldWProc <> 0 Then
-        SetWindowLong hWndMsg, GWL_WNDPROC, OldWProc
+        Call SetWindowLong(hWndMsg, GWL_WNDPROC, OldWProc)
         OldWProc = 0
-
     End If
 
     #If WSAPI_CREAR_LABEL Then
 
         If hWndMsg <> 0 Then
-            DestroyWindow hWndMsg
-
+            Call DestroyWindow(hWndMsg)
         End If
 
     #End If
@@ -137,7 +127,6 @@ Public Function BuscaSlotSock(ByVal S As Long) As Long
         BuscaSlotSock = WSAPISock2Usr.Item(CStr(S))
     Else
         BuscaSlotSock = -1
-
     End If
     
     Exit Function
@@ -153,48 +142,16 @@ Public Sub AgregaSlotSock(ByVal Sock As Long, ByVal Slot As Long)
     If WSAPISock2Usr.Count > MaxUsers Then
         Call CloseSocket(Slot)
         Exit Sub
-
     End If
 
-    WSAPISock2Usr.Add CStr(Slot), CStr(Sock)
-
-    'Dim Pri As Long, Ult As Long, Med As Long
-    'Dim LoopC As Long
-    '
-    'If WSAPISockChacheCant > 0 Then
-    '    Pri = 1
-    '    Ult = WSAPISockChacheCant
-    '    Med = Int((Pri + Ult) / 2)
-    '
-    '    Do While (Pri <= Ult) And (Ult > 1)
-    '        If Sock < WSAPISockChache(Med).Sock Then
-    '            Ult = Med - 1
-    '        Else
-    '            Pri = Med + 1
-    '        End If
-    '        Med = Int((Pri + Ult) / 2)
-    '    Loop
-    '
-    '    Pri = IIf(Sock < WSAPISockChache(Med).Sock, Med, Med + 1)
-    '    Ult = WSAPISockChacheCant
-    '    For LoopC = Ult To Pri Step -1
-    '        WSAPISockChache(LoopC + 1) = WSAPISockChache(LoopC)
-    '    Next LoopC
-    '    Med = Pri
-    'Else
-    '    Med = 1
-    'End If
-    'WSAPISockChache(Med).Slot = Slot
-    'WSAPISockChache(Med).Sock = Sock
-    'WSAPISockChacheCant = WSAPISockChacheCant + 1
+    Call WSAPISock2Usr.Add(CStr(Slot), CStr(Sock))
 
 End Sub
 
 Public Sub BorraSlotSock(ByVal Sock As Long)
 
     Dim cant As Long
-
-    cant = WSAPISock2Usr.Count
+        cant = WSAPISock2Usr.Count
 
     On Error Resume Next
 
@@ -204,23 +161,15 @@ Public Sub BorraSlotSock(ByVal Sock As Long)
 
 End Sub
 
-Public Function WndProc(ByVal hWnd As Long, _
-   ByVal msg As Long, _
-   ByVal wParam As Long, _
-   ByVal lParam As Long) As Long
+Public Function WndProc(ByVal hWnd As Long, ByVal msg As Long, ByVal wParam As Long, ByVal lParam As Long) As Long
 
     On Error Resume Next
 
     Dim ret      As Long
-
     Dim Tmp()    As Byte
-
     Dim S        As Long
-
     Dim e        As Long
-
     Dim n        As Integer
-
     Dim UltError As Long
     
     Select Case msg
@@ -232,49 +181,16 @@ Public Function WndProc(ByVal hWnd As Long, _
             Select Case e
 
                 Case FD_ACCEPT
-
                     If S = SockListen Then
                         Call EventoSockAccept(S)
-
                     End If
-                
-                    '    Case FD_WRITE
-                    '        N = BuscaSlotSock(s)
-                    '        If N < 0 And s <> SockListen Then
-                    '            'Call apiclosesocket(s)
-                    '            call WSApiCloseSocket(s)
-                    '            Exit Function
-                    '        End If
-                    '
-            
-                    '        Call IntentarEnviarDatosEncolados(N)
-                    '
-                    '        Dale = UserList(N).ColaSalida.Count > 0
-                    '        Do While Dale
-                    '            Ret = WsApiEnviar(N, UserList(N).ColaSalida.Item(1), False)
-                    '            If Ret <> 0 Then
-                    '                If Ret = WSAEWOULDBLOCK Then
-                    '                    Dale = False
-                    '                Else
-                    '                    'y aca que hacemo' ?? help! i need somebody, help!
-                    '                    Dale = False
-                    '                    Debug.Print "ERROR AL ENVIAR EL DATO DESDE LA COLA " & Ret & ": " & GetWSAErrorString(Ret)
-                    '                End If
-                    '            Else
-                    '            '    Debug.Print "Dato de la cola enviado"
-                    '                UserList(N).ColaSalida.Remove 1
-                    '                Dale = (UserList(N).ColaSalida.Count > 0)
-                    '            End If
-                    '        Loop
-        
+
                 Case FD_READ
                     n = BuscaSlotSock(S)
 
                     If n < 0 And S <> SockListen Then
-                        'Call apiclosesocket(s)
                         Call WSApiCloseSocket(S)
                         Exit Function
-
                     End If
                     
                     'create appropiate sized buffer
@@ -290,6 +206,7 @@ Public Function WndProc(ByVal hWnd As Long, _
                         If UltError = WSAEMSGSIZE Then
                             Debug.Print "WSAEMSGSIZE"
                             ret = SIZE_RCVBUF
+                        
                         Else
                             Debug.Print "Error en Recv: " & GetWSAErrorString(UltError)
                             Call LogApiSock("Error en Recv: N=" & n & " S=" & S & " Str=" & GetWSAErrorString(UltError))
@@ -323,7 +240,6 @@ Public Function WndProc(ByVal hWnd As Long, _
                         UserList(n).ConnID = -1
                         UserList(n).ConnIDValida = False
                         Call EventoSockClose(n)
-
                     End If
 
             End Select
@@ -340,9 +256,7 @@ End Function
 Public Function WsApiEnviar(ByVal Slot As Integer, ByRef str As String) As Long
 
     Dim ret     As String
-
     Dim Retorno As Long
-
     Dim data()  As Byte
     
     ReDim Preserve data(Len(str) - 1) As Byte
@@ -352,16 +266,15 @@ Public Function WsApiEnviar(ByVal Slot As Integer, ByRef str As String) As Long
     Retorno = 0
     
     If UserList(Slot).ConnID <> -1 And UserList(Slot).ConnIDValida Then
+        
         ret = send(ByVal UserList(Slot).ConnID, data(0), ByVal UBound(data()) + 1, ByVal 0)
 
         If ret < 0 Then
             ret = Err.LastDllError
 
             If ret = WSAEWOULDBLOCK Then
-                
                 ' WSAEWOULDBLOCK, put the data again in the outgoingData Buffer
                 Call UserList(Slot).outgoingData.WriteASCIIStringFixed(str)
-
             End If
 
         End If
@@ -370,7 +283,6 @@ Public Function WsApiEnviar(ByVal Slot As Integer, ByRef str As String) As Long
 
         If Not UserList(Slot).Counters.Saliendo Then
             Retorno = -1
-
         End If
 
     End If
@@ -384,10 +296,10 @@ Public Sub LogApiSock(ByVal str As String)
     On Error GoTo ErrHandler
 
     Dim nfile As Integer
-
-    nfile = FreeFile ' obtenemos un canal
+        nfile = FreeFile ' obtenemos un canal
+        
     Open App.Path & "\logs\wsapi.log" For Append Shared As #nfile
-    Print #nfile, Date & " " & time & " " & str
+        Print #nfile, Date & " " & time & " " & str
     Close #nfile
 
     Exit Sub
@@ -403,65 +315,45 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
     '========================
     
     Dim NewIndex  As Integer
-
     Dim ret       As Long
-
-    Dim Tam       As Long, sa As sockaddr
-
+    Dim Tam       As Long
+    Dim sa        As sockaddr
     Dim NuevoSock As Long
-
     Dim i         As Long
-
     Dim str       As String
-
     Dim data()    As Byte
     
     Tam = sockaddr_size
     
-    '=============================================
+    '================================================
     'SockID es en este caso es el socket de escucha,
     'a diferencia de socketwrench que es el nuevo
     'socket de la nueva conn
+    '================================================
     
     'Modificado por Maraxus
-    'ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 0)
     ret = accept(SockID, sa, Tam)
 
     If ret = INVALID_SOCKET Then
         i = Err.LastDllError
         Call LogCriticEvent("Error en Accept() API " & i & ": " & GetWSAErrorString(i))
         Exit Sub
-
     End If
-
-    'If ret = INVALID_SOCKET Then
-    '    If Err.LastDllError = 11002 Then
-    '        ' We couldn't decide if to accept or reject the connection
-    '        'Force reject so we can get it out of the queue
-    '        ret = WSAAccept(SockID, sa, Tam, AddressOf CondicionSocket, 1)
-    '        Call LogCriticEvent("Error en WSAAccept() API 11002: No se pudo decidir si aceptar o rechazar la conexion.")
-    '    Else
-    '        i = Err.LastDllError
-    '        Call LogCriticEvent("Error en WSAAccept() API " & i & ": " & GetWSAErrorString(i))
-    '        Exit Sub
-    '    End If
-    'End If
 
     NuevoSock = ret
     
     If setsockopt(NuevoSock, SOL_SOCKET, SO_LINGER, 0, 4) <> 0 Then
         i = Err.LastDllError
         Call LogCriticEvent("Error al setear lingers." & i & ": " & GetWSAErrorString(i))
-
     End If
     
     If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
         Call WSApiCloseSocket(NuevoSock)
         Exit Sub
-
     End If
     
     If SecurityIp.IPSecuritySuperaLimiteConexiones(sa.sin_addr) Then
+        
         str = Protocol.PrepareMessageErrorMsg("Limite de conexiones para su IP alcanzado.")
         
         ReDim Preserve data(Len(str) - 1) As Byte
@@ -469,7 +361,9 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
         data = StrConv(str, vbFromUnicode)
         
         Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
+        
         Call WSApiCloseSocket(NuevoSock)
+        
         Exit Sub
 
     End If
@@ -485,7 +379,6 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
     If setsockopt(NuevoSock, SOL_SOCKET, SO_SNDBUFFER, SIZE_SNDBUF, 4) <> 0 Then
         i = Err.LastDllError
         Call LogCriticEvent("Error al setear el tamano del buffer de salida " & i & ": " & GetWSAErrorString(i))
-
     End If
     
     '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -509,7 +402,6 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
         For i = 1 To BanIps.Count
 
             If BanIps.Item(i) = UserList(NewIndex).IP Then
-                'Call apiclosesocket(NuevoSock)
                 Call WriteErrorMsg(NewIndex, "Su IP se encuentra bloqueada en este servidor.")
                 Call FlushBuffer(NewIndex)
                 Call SecurityIp.IpRestarConexion(sa.sin_addr)
@@ -526,7 +418,9 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
         UserList(NewIndex).ConnIDValida = True
         
         Call AgregaSlotSock(NuevoSock, NewIndex)
+        
     Else
+        
         str = Protocol.PrepareMessageErrorMsg("El servidor se encuentra lleno en este momento. Disculpe las molestias ocasionadas.")
         
         ReDim Preserve data(Len(str) - 1) As Byte
@@ -534,6 +428,7 @@ Public Sub EventoSockAccept(ByVal SockID As Long)
         data = StrConv(str, vbFromUnicode)
         
         Call send(ByVal NuevoSock, data(0), ByVal UBound(data()) + 1, ByVal 0)
+        
         Call WSApiCloseSocket(NuevoSock)
 
     End If
@@ -547,10 +442,11 @@ Public Sub EventoSockRead(ByVal Slot As Integer, ByRef Datos() As Byte)
         Call .incomingData.WriteBlock(Datos)
     
         If .ConnID <> -1 Then
-
-            Do While HandleIncomingData(Slot) = True
-            Loop
+            
+            Do While HandleIncomingData(Slot) = True: Loop
+        
         Else
+        
             Exit Sub
 
         End If
@@ -564,7 +460,6 @@ Public Sub EventoSockClose(ByVal Slot As Integer)
     'maTih.-  Nuevo centinela.
     If UserList(Slot).CentinelaUsuario.centinelaIndex <> 0 Then
         Call modCentinela.UsuarioInActivo(Slot)
-
     End If
 
     If UserList(Slot).flags.UserLogged Then
@@ -572,7 +467,6 @@ Public Sub EventoSockClose(ByVal Slot As Integer)
         Call Cerrar_Usuario(Slot)
     Else
         Call CloseSocket(Slot)
-
     End If
 
 End Sub
@@ -589,10 +483,8 @@ Public Sub WSApiReiniciarSockets()
 
         If UserList(i).ConnID <> -1 And UserList(i).ConnIDValida Then
             Call CloseSocket(i)
-
         End If
-        
-        'Call ResetUserSlot(i)
+
     Next i
     
     For i = 1 To MaxUsers
@@ -617,6 +509,7 @@ Public Sub WSApiReiniciarSockets()
     Call LimpiaWsApi
     Call Sleep(100)
     Call IniciaWsApi(frmMain.hWnd)
+    
     SockListen = ListenForConnect(Puerto, hWndMsg, vbNullString)
 
 End Sub
@@ -624,37 +517,34 @@ End Sub
 Public Sub WSApiCloseSocket(ByVal Socket As Long)
 
     Call WSAAsyncSelect(Socket, hWndMsg, ByVal 1025, ByVal (FD_CLOSE))
+    
     Call ShutDown(Socket, SD_BOTH)
 
 End Sub
 
 Public Function CondicionSocket(ByRef lpCallerId As WSABUF, _
-   ByRef lpCallerData As WSABUF, _
-   ByRef lpSQOS As FLOWSPEC, _
-   ByVal Reserved As Long, _
-   ByRef lpCalleeId As WSABUF, _
-   ByRef lpCalleeData As WSABUF, _
-   ByRef Group As Long, _
-   ByVal dwCallbackData As Long) As Long
+                                ByRef lpCallerData As WSABUF, _
+                                ByRef lpSQOS As FLOWSPEC, _
+                                ByVal Reserved As Long, _
+                                ByRef lpCalleeId As WSABUF, _
+                                ByRef lpCalleeData As WSABUF, _
+                                ByRef Group As Long, _
+                                ByVal dwCallbackData As Long) As Long
 
     Dim sa As sockaddr
     
     'Check if we were requested to force reject
-
     If dwCallbackData = 1 Then
         CondicionSocket = CF_REJECT
         Exit Function
-
     End If
     
     'Get the address
-
-    CopyMemory sa, ByVal lpCallerId.lpBuffer, lpCallerId.dwBufferLen
+    Call CopyMemory(sa, ByVal lpCallerId.lpBuffer, lpCallerId.dwBufferLen)
     
     If Not SecurityIp.IpSecurityAceptarNuevaConexion(sa.sin_addr) Then
         CondicionSocket = CF_REJECT
         Exit Function
-
     End If
 
     CondicionSocket = CF_ACCEPT 'En realdiad es al pedo, porque CondicionSocket se inicializa a 0, pero asi es mas claro....

--- a/Codigo/wsksock.bas
+++ b/Codigo/wsksock.bas
@@ -18,862 +18,326 @@ Attribute VB_Name = "WSKSOCK"
 'along with this program; if not, you can find it at http://www.affero.org/oagpl.html
 '**************************************************************************
 
-#If UsarQueSocket = 1 Then
+'date stamp: sept 1, 1996 (for version control, please don't remove)
+
+'Visual Basic 4.0 Winsock "Header"
+'   Alot of the information contained inside this file was originally
+'   obtained from ALT.WINSOCK.PROGRAMMING and most of it has since been
+'   modified in some way.
+'
+'Disclaimer: This file is public domain, updated periodically by
+'   Topaz, SigSegV@mail.utexas.edu, Use it at your own risk.
+'   Neither myself(Topaz) or anyone related to alt.programming.winsock
+'   may be held liable for its use, or misuse.
+'
+'Declare check Aug 27, 1996. (Topaz, SigSegV@mail.utexas.edu)
+'   All 16 bit declarations appear correct, even the odd ones that
+'   pass longs inplace of in_addr and char buffers. 32 bit functions
+'   also appear correct. Some are declared to return integers instead of
+'   longs (breaking MS's rules.) however after testing these functions I
+'   have come to the conclusion that they do not work properly when declared
+'   following MS's rules.
+'
+'NOTES:
+'   (1) I have never used WS_SELECT (select), therefore I must warn that I do
+'       not know if fd_set and timeval are properly defined.
+'   (2) Alot of the functions are declared with "buf as any", when calling these
+'       functions you may either pass strings, byte arrays or UDT's. For 32bit I
+'       I recommend Byte arrays and the use of memcopy to copy the data back out
+'   (3) The async functions (wsaAsync*) require the use of a message hook or
+'       message window control to capture messages sent by the winsock stack. This
+'       is not to be confused with a CallBack control, The only function that uses
+'       callbacks is WSASetBlockingHook()
+'   (4) Alot of "helper" functions are provided in the file for various things
+'       before attempting to figure out how to call a function, look and see if
+'       there is already a helper function for it.
+'   (5) Data types (hostent etc) have kept there 16bit definitions, even under 32bit
+'       windows due to the problem of them not working when redfined following the
+'       suggested rules.
+Option Explicit
 
-    'date stamp: sept 1, 1996 (for version control, please don't remove)
+Public Const FD_SETSIZE = 64
 
-    'Visual Basic 4.0 Winsock "Header"
-    '   Alot of the information contained inside this file was originally
-    '   obtained from ALT.WINSOCK.PROGRAMMING and most of it has since been
-    '   modified in some way.
-    '
-    'Disclaimer: This file is public domain, updated periodically by
-    '   Topaz, SigSegV@mail.utexas.edu, Use it at your own risk.
-    '   Neither myself(Topaz) or anyone related to alt.programming.winsock
-    '   may be held liable for its use, or misuse.
-    '
-    'Declare check Aug 27, 1996. (Topaz, SigSegV@mail.utexas.edu)
-    '   All 16 bit declarations appear correct, even the odd ones that
-    '   pass longs inplace of in_addr and char buffers. 32 bit functions
-    '   also appear correct. Some are declared to return integers instead of
-    '   longs (breaking MS's rules.) however after testing these functions I
-    '   have come to the conclusion that they do not work properly when declared
-    '   following MS's rules.
-    '
-    'NOTES:
-    '   (1) I have never used WS_SELECT (select), therefore I must warn that I do
-    '       not know if fd_set and timeval are properly defined.
-    '   (2) Alot of the functions are declared with "buf as any", when calling these
-    '       functions you may either pass strings, byte arrays or UDT's. For 32bit I
-    '       I recommend Byte arrays and the use of memcopy to copy the data back out
-    '   (3) The async functions (wsaAsync*) require the use of a message hook or
-    '       message window control to capture messages sent by the winsock stack. This
-    '       is not to be confused with a CallBack control, The only function that uses
-    '       callbacks is WSASetBlockingHook()
-    '   (4) Alot of "helper" functions are provided in the file for various things
-    '       before attempting to figure out how to call a function, look and see if
-    '       there is already a helper function for it.
-    '   (5) Data types (hostent etc) have kept there 16bit definitions, even under 32bit
-    '       windows due to the problem of them not working when redfined following the
-    '       suggested rules.
-    Option Explicit
+Type fd_set
+
+    fd_count As Integer
+    fd_array(FD_SETSIZE) As Integer
 
-    Public Const FD_SETSIZE = 64
+End Type
 
-    Type fd_set
+Type timeval
 
-        fd_count As Integer
-        fd_array(FD_SETSIZE) As Integer
+    tv_sec As Long
+    tv_usec As Long
 
-    End Type
+End Type
 
-    Type timeval
+Type HostEnt
 
-        tv_sec As Long
-        tv_usec As Long
+    h_name As Long
+    h_aliases As Long
+    h_addrtype As Integer
+    h_length As Integer
+    h_addr_list As Long
+
+End Type
+
+Public Const hostent_size = 16
+
+Type servent
+
+    s_name As Long
+    s_aliases As Long
+    s_port As Integer
+    s_proto As Long
 
-    End Type
-
-    Type HostEnt
-
-        h_name As Long
-        h_aliases As Long
-        h_addrtype As Integer
-        h_length As Integer
-        h_addr_list As Long
-
-    End Type
-
-    Public Const hostent_size = 16
-
-    Type servent
-
-        s_name As Long
-        s_aliases As Long
-        s_port As Integer
-        s_proto As Long
-
-    End Type
-
-    Public Const servent_size = 14
-
-    Type protoent
-
-        p_name As Long
-        p_aliases As Long
-        p_proto As Integer
-
-    End Type
-
-    Public Const protoent_size = 10
-
-    Public Const IPPROTO_TCP = 6
-
-    Public Const IPPROTO_UDP = 17
-
-    Public Const INADDR_NONE = &HFFFFFFFF
-
-    Public Const INADDR_ANY = &H0
-
-    Type sockaddr
-
-        sin_family As Integer
-        sin_port As Integer
-        sin_addr As Long
-        sin_zero As String * 8
-
-    End Type
-
-    Public Const sockaddr_size = 16
-
-    Public saZero As sockaddr
-
-    Public Const WSA_DESCRIPTIONLEN = 256
-
-    Public Const WSA_DescriptionSize = WSA_DESCRIPTIONLEN + 1
-
-    Public Const WSA_SYS_STATUS_LEN = 128
-
-    Public Const WSA_SysStatusSize = WSA_SYS_STATUS_LEN + 1
-
-    Type WSADataType
-
-        wVersion As Integer
-        wHighVersion As Integer
-        szDescription As String * WSA_DescriptionSize
-        szSystemStatus As String * WSA_SysStatusSize
-        iMaxSockets As Integer
-        iMaxUdpDg As Integer
-        lpVendorInfo As Long
-
-    End Type
-
-    'Agregado por Maraxus
-    Type WSABUF
-
-        dwBufferLen As Long
-        lpBuffer    As Long
-
-    End Type
-
-    'Agregado por Maraxus
-    Type FLOWSPEC
-
-        TokenRate           As Long     'In Bytes/sec
-        TokenBucketSize     As Long     'In Bytes
-        PeakBandwidth       As Long     'In Bytes/sec
-        Latency             As Long     'In microseconds
-        DelayVariation      As Long     'In microseconds
-        ServiceType         As Integer  'Guaranteed, Predictive,
-        'Best Effort, etc.
-        MaxSduSize          As Long     'In Bytes
-        MinimumPolicedSize  As Long     'In Bytes
-
-    End Type
-
-    'Agregado por Maraxus
-    Public Const WSA_FLAG_OVERLAPPED = &H1
-
-    'Agregados por Maraxus
-    Public Const CF_ACCEPT = &H0
-
-    Public Const CF_REJECT = &H1
-
-    'Agregado por Maraxus
-    Public Const SD_RECEIVE As Long = &H0&
-
-    Public Const SD_SEND    As Long = &H1&
-
-    Public Const SD_BOTH    As Long = &H2&
-
-    Public Const INVALID_SOCKET = -1
-
-    Public Const SOCKET_ERROR = -1
-
-    Public Const SOCK_STREAM = 1
-
-    Public Const SOCK_DGRAM = 2
-
-    Public Const MAXGETHOSTSTRUCT = 1024
-
-    Public Const AF_INET = 2
-
-    Public Const PF_INET = 2
-
-    Type LingerType
-
-        l_onoff As Integer
-        l_linger As Integer
-
-    End Type
-
-    ' Windows Sockets definitions of regular Microsoft C error constants
-    Global Const WSAEINTR = 10004
-
-    Global Const WSAEBADF = 10009
-
-    Global Const WSAEACCES = 10013
-
-    Global Const WSAEFAULT = 10014
-
-    Global Const WSAEINVAL = 10022
-
-    Global Const WSAEMFILE = 10024
-
-    ' Windows Sockets definitions of regular Berkeley error constants
-    Global Const WSAEWOULDBLOCK = 10035
-
-    Global Const WSAEINPROGRESS = 10036
-
-    Global Const WSAEALREADY = 10037
-
-    Global Const WSAENOTSOCK = 10038
-
-    Global Const WSAEDESTADDRREQ = 10039
-
-    Global Const WSAEMSGSIZE = 10040
-
-    Global Const WSAEPROTOTYPE = 10041
-
-    Global Const WSAENOPROTOOPT = 10042
-
-    Global Const WSAEPROTONOSUPPORT = 10043
-
-    Global Const WSAESOCKTNOSUPPORT = 10044
-
-    Global Const WSAEOPNOTSUPP = 10045
-
-    Global Const WSAEPFNOSUPPORT = 10046
-
-    Global Const WSAEAFNOSUPPORT = 10047
-
-    Global Const WSAEADDRINUSE = 10048
-
-    Global Const WSAEADDRNOTAVAIL = 10049
-
-    Global Const WSAENETDOWN = 10050
-
-    Global Const WSAENETUNREACH = 10051
-
-    Global Const WSAENETRESET = 10052
-
-    Global Const WSAECONNABORTED = 10053
-
-    Global Const WSAECONNRESET = 10054
-
-    Global Const WSAENOBUFS = 10055
-
-    Global Const WSAEISCONN = 10056
-
-    Global Const WSAENOTCONN = 10057
-
-    Global Const WSAESHUTDOWN = 10058
-
-    Global Const WSAETOOMANYREFS = 10059
-
-    Global Const WSAETIMEDOUT = 10060
-
-    Global Const WSAECONNREFUSED = 10061
-
-    Global Const WSAELOOP = 10062
-
-    Global Const WSAENAMETOOLONG = 10063
-
-    Global Const WSAEHOSTDOWN = 10064
-
-    Global Const WSAEHOSTUNREACH = 10065
-
-    Global Const WSAENOTEMPTY = 10066
-
-    Global Const WSAEPROCLIM = 10067
-
-    Global Const WSAEUSERS = 10068
-
-    Global Const WSAEDQUOT = 10069
-
-    Global Const WSAESTALE = 10070
-
-    Global Const WSAEREMOTE = 10071
-
-    ' Extended Windows Sockets error constant definitions
-    Global Const WSASYSNOTREADY = 10091
-
-    Global Const WSAVERNOTSUPPORTED = 10092
-
-    Global Const WSANOTINITIALISED = 10093
-
-    Global Const WSAHOST_NOT_FOUND = 11001
-
-    Global Const WSATRY_AGAIN = 11002
-
-    Global Const WSANO_RECOVERY = 11003
-
-    Global Const WSANO_DATA = 11004
-
-    Global Const WSANO_ADDRESS = 11004
-
-    '---ioctl Constants
-    Public Const FIONREAD = &H8004667F
-
-    Public Const FIONBIO = &H8004667E
-
-    Public Const FIOASYNC = &H8004667D
-
-    #If Win16 Then
-
-        '---Windows System functions
-        Public Declare Function PostMessage _
-                       Lib "User" (ByVal hWnd As Integer, _
-                                   ByVal wMsg As Integer, _
-                                   ByVal wParam As Integer, _
-                                   lParam As Any) As Integer
-
-        Public Declare Sub MemCopy _
-                       Lib "Kernel" _
-                       Alias "hmemcpy" (Dest As Any, _
-                                        Src As Any, _
-                                        ByVal cb&)
-
-        Public Declare Function lstrlen Lib "Kernel" (ByVal lpString As Any) As Integer
-
-        '---async notification constants
-        Public Const SOL_SOCKET = &HFFFF
-
-        Public Const SO_LINGER = &H80
-
-        Public Const SO_RCVBUFFER = &H1002              ' Agregado por Maraxus
-
-        Public Const SO_SNDBUFFER = &H1001              ' Agregado por Maraxus
-
-        Public Const SO_CONDITIONAL_ACCEPT = &H3002    ' Agregado por Maraxus
-
-        Public Const FD_READ = &H1
-
-        Public Const FD_WRITE = &H2
-
-        Public Const FD_OOB = &H4
-
-        Public Const FD_ACCEPT = &H8
-
-        Public Const FD_CONNECT = &H10
-
-        Public Const FD_CLOSE = &H20
-
-        '---SOCKET FUNCTIONS
-        Public Declare Function accept _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         addr As sockaddr, _
-                                         AddrLen As Integer) As Integer
-
-        Public Declare Function bind _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         addr As sockaddr, _
-                                         ByVal namelen As Integer) As Integer
-
-        Public Declare Function apiclosesocket _
-                       Lib "ws2_32.DLL" _
-                       Alias "closesocket" (ByVal S As Integer) As Integer
-
-        Public Declare Function connect _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         addr As sockaddr, _
-                                         ByVal namelen As Integer) As Integer
-
-        Public Declare Function ioctlsocket _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByVal Cmd As Long, _
-                                         argp As Long) As Integer
-
-        Public Declare Function getpeername _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         sName As sockaddr, _
-                                         namelen As Integer) As Integer
-
-        Public Declare Function getsockname _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         sName As sockaddr, _
-                                         namelen As Integer) As Integer
-
-        Public Declare Function getsockopt _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByVal level As Integer, _
-                                         ByVal optname As Integer, _
-                                         optval As Any, _
-                                         optlen As Integer) As Integer
-
-        Public Declare Function htonl Lib "ws2_32.DLL" (ByVal hostlong As Long) As Long
-
-        Public Declare Function htons _
-                       Lib "ws2_32.DLL" (ByVal hostshort As Integer) As Integer
-
-        Public Declare Function inet_addr Lib "ws2_32.DLL" (ByVal cp As String) As Long
-
-        Public Declare Function inet_ntoa Lib "ws2_32.DLL" (ByVal inn As Long) As Long
-
-        Public Declare Function listen _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByVal backlog As Integer) As Integer
-
-        Public Declare Function ntohl Lib "ws2_32.DLL" (ByVal netlong As Long) As Long
-
-        Public Declare Function ntohs _
-                       Lib "ws2_32.DLL" (ByVal netshort As Integer) As Integer
-
-        Public Declare Function recv _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByRef buf As Any, _
-                                         ByVal buflen As Integer, _
-                                         ByVal flags As Integer) As Integer
-
-        Public Declare Function recvfrom _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer, _
-                                         ByVal flags As Integer, _
-                                         from As sockaddr, _
-                                         fromlen As Integer) As Integer
-
-        Public Declare Function ws_select _
-                       Lib "ws2_32.DLL" _
-                       Alias "select" (ByVal nfds As Integer, _
-                                       readfds As Any, _
-                                       writefds As Any, _
-                                       exceptfds As Any, _
-                                       timeout As timeval) As Integer
-
-        Public Declare Function send _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer, _
-                                         ByVal flags As Integer) As Integer
-
-        Public Declare Function sendto _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer, _
-                                         ByVal flags As Integer, _
-                                         to_addr As sockaddr, _
-                                         ByVal tolen As Integer) As Integer
-
-        Public Declare Function setsockopt _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByVal level As Integer, _
-                                         ByVal optname As Integer, _
-                                         optval As Any, _
-                                         ByVal optlen As Integer) As Integer
-
-        Public Declare Function ShutDown _
-                       Lib "ws2_32.DLL" _
-                       Alias "shutdown" (ByVal S As Integer, _
-                                         ByVal how As Integer) As Integer
-
-        Public Declare Function Socket _
-                       Lib "ws2_32.DLL" _
-                       Alias "socket" (ByVal af As Integer, _
-                                       ByVal s_type As Integer, _
-                                       ByVal Protocol As Integer) As Integer
-
-        '---DATABASE FUNCTIONS
-        Public Declare Function gethostbyaddr _
-                       Lib "ws2_32.DLL" (addr As Long, _
-                                         ByVal addr_len As Integer, _
-                                         ByVal addr_type As Integer) As Long
-
-        Public Declare Function gethostbyname _
-                       Lib "ws2_32.DLL" (ByVal host_name As String) As Long
-
-        Public Declare Function gethostname _
-                       Lib "ws2_32.DLL" (ByVal host_name As String, _
-                                         ByVal namelen As Integer) As Integer
-
-        Public Declare Function getservbyport _
-                       Lib "ws2_32.DLL" (ByVal Port As Integer, _
-                                         ByVal proto As String) As Long
-
-        Public Declare Function getservbyname _
-                       Lib "ws2_32.DLL" (ByVal serv_name As String, _
-                                         ByVal proto As String) As Long
-
-        Public Declare Function getprotobynumber _
-                       Lib "ws2_32.DLL" (ByVal proto As Integer) As Long
-
-        Public Declare Function getprotobyname _
-                       Lib "ws2_32.DLL" (ByVal proto_name As String) As Long
-
-        '---WINDOWS EXTENSIONS
-        Public Declare Function WSAStartup _
-                       Lib "ws2_32.DLL" (ByVal wVR As Integer, _
-                                         lpWSAD As WSADataType) As Integer
-
-        Public Declare Function WSACleanup Lib "ws2_32.DLL" () As Integer
-
-        Public Declare Sub WSASetLastError Lib "ws2_32.DLL" (ByVal iError As Integer)
-
-        Public Declare Function WSAGetLastError Lib "ws2_32.DLL" () As Integer
-
-        Public Declare Function WSAIsBlocking Lib "ws2_32.DLL" () As Integer
-
-        Public Declare Function WSAUnhookBlockingHook Lib "ws2_32.DLL" () As Integer
-
-        Public Declare Function WSASetBlockingHook _
-                       Lib "ws2_32.DLL" (ByVal lpBlockFunc As Long) As Long
-
-        Public Declare Function WSACancelBlockingCall Lib "ws2_32.DLL" () As Integer
-
-        Public Declare Function WSAAsyncGetServByName _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal serv_name As String, _
-                                         ByVal proto As String, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSAAsyncGetServByPort _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal Port As Integer, _
-                                         ByVal proto As String, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSAAsyncGetProtoByName _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal proto_name As String, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSAAsyncGetProtoByNumber _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal Number As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSAAsyncGetHostByName _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal host_name As String, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSAAsyncGetHostByAddr _
-                       Lib "ws2_32.DLL" (ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         addr As Long, _
-                                         ByVal addr_len As Integer, _
-                                         ByVal addr_type As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer) As Integer
-
-        Public Declare Function WSACancelAsyncRequest _
-                       Lib "ws2_32.DLL" (ByVal hAsyncTaskHandle As Integer) As Integer
-
-        Public Declare Function WSAAsyncSelect _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         ByVal hWnd As Integer, _
-                                         ByVal wMsg As Integer, _
-                                         ByVal lEvent As Long) As Integer
-
-        Public Declare Function WSARecvEx _
-                       Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                         buf As Any, _
-                                         ByVal buflen As Integer, _
-                                         ByVal flags As Integer) As Integer
-        'Agregado por Maraxus
-        Declare Function WSAAccept _
-                Lib "ws2_32.DLL" (ByVal S As Integer, _
-                                  pSockAddr As sockaddr, _
-                                  AddrLen As Integer, _
-                                  ByVal lpfnCondition As Long, _
-                                  ByVal dwCallbackData As Long) As Integer
-    
-        Public Const SOMAXCONN As Integer = &H7FFF            ' Agregado por Maraxus
-
-    #ElseIf Win32 Then
-
-        '---Windows System Functions
-        Public Declare Function PostMessage _
-                       Lib "user32" _
-                       Alias "PostMessageA" (ByVal hWnd As Long, _
-                                             ByVal wMsg As Long, _
-                                             ByVal wParam As Long, _
-                                             ByVal lParam As Long) As Long
-
-        Public Declare Sub MemCopy _
-                       Lib "kernel32" _
-                       Alias "RtlMoveMemory" (Dest As Any, _
-                                              Src As Any, _
-                                              ByVal cb&)
-
-        Public Declare Function lstrlen _
-                       Lib "kernel32" _
-                       Alias "lstrlenA" (ByVal lpString As Any) As Long
-
-        '---async notification constants
-        Public Const SOL_SOCKET = &HFFFF&
-
-        Public Const SO_LINGER = &H80&
-
-        Public Const SO_RCVBUFFER = &H1002&             ' Agregado por Maraxus
-
-        Public Const SO_SNDBUFFER = &H1001&              ' Agregado por Maraxus
-
-        Public Const SO_CONDITIONAL_ACCEPT = &H3002&    ' Agregado por Maraxus
-
-        Public Const FD_READ = &H1&
-
-        Public Const FD_WRITE = &H2&
-
-        Public Const FD_OOB = &H4&
-
-        Public Const FD_ACCEPT = &H8&
-
-        Public Const FD_CONNECT = &H10&
-
-        Public Const FD_CLOSE = &H20&
-
-        '---SOCKET FUNCTIONS
-        Public Declare Function accept _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          addr As sockaddr, _
-                                          AddrLen As Long) As Long
-
-        Public Declare Function bind _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          addr As sockaddr, _
-                                          ByVal namelen As Long) As Long
-
-        Public Declare Function apiclosesocket _
-                       Lib "wsock32.dll" _
-                       Alias "closesocket" (ByVal S As Long) As Long
-
-        Public Declare Function connect _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          addr As sockaddr, _
-                                          ByVal namelen As Long) As Long
-
-        Public Declare Function ioctlsocket _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByVal Cmd As Long, _
-                                          argp As Long) As Long
-
-        Public Declare Function getpeername _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          sName As sockaddr, _
-                                          namelen As Long) As Long
-
-        Public Declare Function getsockname _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          sName As sockaddr, _
-                                          namelen As Long) As Long
-
-        Public Declare Function getsockopt _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByVal level As Long, _
-                                          ByVal optname As Long, _
-                                          optval As Any, _
-                                          optlen As Long) As Long
-
-        Public Declare Function htonl Lib "wsock32.dll" (ByVal hostlong As Long) As Long
-
-        Public Declare Function htons _
-                       Lib "wsock32.dll" (ByVal hostshort As Long) As Integer
-
-        Public Declare Function inet_addr Lib "wsock32.dll" (ByVal cp As String) As Long
-
-        Public Declare Function inet_ntoa Lib "wsock32.dll" (ByVal inn As Long) As Long
-
-        Public Declare Function listen _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByVal backlog As Long) As Long
-
-        Public Declare Function ntohl Lib "wsock32.dll" (ByVal netlong As Long) As Long
-
-        Public Declare Function ntohs _
-                       Lib "wsock32.dll" (ByVal netshort As Long) As Integer
-
-        Public Declare Function recv _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByRef buf As Any, _
-                                          ByVal buflen As Long, _
-                                          ByVal flags As Long) As Long
-
-        Public Declare Function recvfrom _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long, _
-                                          ByVal flags As Long, _
-                                          from As sockaddr, _
-                                          fromlen As Long) As Long
-
-        Public Declare Function ws_select _
-                       Lib "wsock32.dll" _
-                       Alias "select" (ByVal nfds As Long, _
-                                       readfds As fd_set, _
-                                       writefds As fd_set, _
-                                       exceptfds As fd_set, _
-                                       timeout As timeval) As Long
-
-        Public Declare Function send _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long, _
-                                          ByVal flags As Long) As Long
-
-        Public Declare Function sendto _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long, _
-                                          ByVal flags As Long, _
-                                          to_addr As sockaddr, _
-                                          ByVal tolen As Long) As Long
-
-        Public Declare Function setsockopt _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByVal level As Long, _
-                                          ByVal optname As Long, _
-                                          optval As Any, _
-                                          ByVal optlen As Long) As Long
-
-        Public Declare Function ShutDown _
-                       Lib "wsock32.dll" _
-                       Alias "shutdown" (ByVal S As Long, _
-                                         ByVal how As Long) As Long
-
-        Public Declare Function Socket _
-                       Lib "wsock32.dll" _
-                       Alias "socket" (ByVal af As Long, _
-                                       ByVal s_type As Long, _
-                                       ByVal Protocol As Long) As Long
-
-        '---DATABASE FUNCTIONS
-        Public Declare Function gethostbyaddr _
-                       Lib "wsock32.dll" (addr As Long, _
-                                          ByVal addr_len As Long, _
-                                          ByVal addr_type As Long) As Long
-
-        Public Declare Function gethostbyname _
-                       Lib "wsock32.dll" (ByVal host_name As String) As Long
-
-        Public Declare Function gethostname _
-                       Lib "wsock32.dll" (ByVal host_name As String, _
-                                          ByVal namelen As Long) As Long
-
-        Public Declare Function getservbyport _
-                       Lib "wsock32.dll" (ByVal Port As Long, _
-                                          ByVal proto As String) As Long
-
-        Public Declare Function getservbyname _
-                       Lib "wsock32.dll" (ByVal serv_name As String, _
-                                          ByVal proto As String) As Long
-
-        Public Declare Function getprotobynumber _
-                       Lib "wsock32.dll" (ByVal proto As Long) As Long
-
-        Public Declare Function getprotobyname _
-                       Lib "wsock32.dll" (ByVal proto_name As String) As Long
-
-        '---WINDOWS EXTENSIONS
-        Public Declare Function WSAStartup _
-                       Lib "wsock32.dll" (ByVal wVR As Long, _
-                                          lpWSAD As WSADataType) As Long
-
-        Public Declare Function WSACleanup Lib "wsock32.dll" () As Long
-
-        Public Declare Sub WSASetLastError Lib "wsock32.dll" (ByVal iError As Long)
-
-        Public Declare Function WSAGetLastError Lib "wsock32.dll" () As Long
-
-        Public Declare Function WSAIsBlocking Lib "wsock32.dll" () As Long
-
-        Public Declare Function WSAUnhookBlockingHook Lib "wsock32.dll" () As Long
-
-        Public Declare Function WSASetBlockingHook _
-                       Lib "wsock32.dll" (ByVal lpBlockFunc As Long) As Long
-
-        Public Declare Function WSACancelBlockingCall Lib "wsock32.dll" () As Long
-
-        Public Declare Function WSAAsyncGetServByName _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal serv_name As String, _
-                                          ByVal proto As String, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSAAsyncGetServByPort _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal Port As Long, _
-                                          ByVal proto As String, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSAAsyncGetProtoByName _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal proto_name As String, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSAAsyncGetProtoByNumber _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal Number As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSAAsyncGetHostByName _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal host_name As String, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSAAsyncGetHostByAddr _
-                       Lib "wsock32.dll" (ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          addr As Long, _
-                                          ByVal addr_len As Long, _
-                                          ByVal addr_type As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long) As Long
-
-        Public Declare Function WSACancelAsyncRequest _
-                       Lib "wsock32.dll" (ByVal hAsyncTaskHandle As Long) As Long
-
-        Public Declare Function WSAAsyncSelect _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          ByVal hWnd As Long, _
-                                          ByVal wMsg As Long, _
-                                          ByVal lEvent As Long) As Long
-
-        Public Declare Function WSARecvEx _
-                       Lib "wsock32.dll" (ByVal S As Long, _
-                                          buf As Any, _
-                                          ByVal buflen As Long, _
-                                          ByVal flags As Long) As Long
-        'Agregado por Maraxus
-        Declare Function WSAAccept _
-                Lib "ws2_32.DLL" (ByVal S As Long, _
-                                  pSockAddr As sockaddr, _
-                                  AddrLen As Long, _
-                                  ByVal lpfnCondition As Long, _
-                                  ByVal dwCallbackData As Long) As Long
-
-        Public Const SOMAXCONN As Long = &H7FFFFFFF            ' Agregado por Maraxus
-
-    #End If
-
-    'SOME STUFF I ADDED
-    Public MySocket%
-
-    Public SockReadBuffer$
-
-    Public Const WSA_NoName = "Unknown"
-
-    Public WSAStartedUp As Boolean     'Flag to keep track of whether winsock WSAStartup wascalled
+End Type
+
+Public Const servent_size = 14
+
+Type protoent
+
+    p_name As Long
+    p_aliases As Long
+    p_proto As Integer
+
+End Type
+
+Public Const protoent_size = 10
+
+Public Const IPPROTO_TCP = 6
+Public Const IPPROTO_UDP = 17
+Public Const INADDR_NONE = &HFFFFFFFF
+Public Const INADDR_ANY = &H0
+
+Type sockaddr
+
+    sin_family As Integer
+    sin_port As Integer
+    sin_addr As Long
+    sin_zero As String * 8
+
+End Type
+
+Public Const sockaddr_size = 16
+
+Public saZero As sockaddr
+
+Public Const WSA_DESCRIPTIONLEN = 256
+Public Const WSA_DescriptionSize = WSA_DESCRIPTIONLEN + 1
+Public Const WSA_SYS_STATUS_LEN = 128
+Public Const WSA_SysStatusSize = WSA_SYS_STATUS_LEN + 1
+
+Type WSADataType
+
+    wVersion As Integer
+    wHighVersion As Integer
+    szDescription As String * WSA_DescriptionSize
+    szSystemStatus As String * WSA_SysStatusSize
+    iMaxSockets As Integer
+    iMaxUdpDg As Integer
+    lpVendorInfo As Long
+
+End Type
+
+'Agregado por Maraxus
+Type WSABUF
+
+    dwBufferLen As Long
+    lpBuffer    As Long
+
+End Type
+
+'Agregado por Maraxus
+Type FLOWSPEC
+
+    TokenRate           As Long     'In Bytes/sec
+    TokenBucketSize     As Long     'In Bytes
+    PeakBandwidth       As Long     'In Bytes/sec
+    Latency             As Long     'In microseconds
+    DelayVariation      As Long     'In microseconds
+    ServiceType         As Integer  'Guaranteed, Predictive,
+    'Best Effort, etc.
+    MaxSduSize          As Long     'In Bytes
+    MinimumPolicedSize  As Long     'In Bytes
+
+End Type
+
+'Agregado por Maraxus
+Public Const WSA_FLAG_OVERLAPPED = &H1
+
+'Agregados por Maraxus
+Public Const CF_ACCEPT = &H0
+Public Const CF_REJECT = &H1
+
+'Agregado por Maraxus
+Public Const SD_RECEIVE As Long = &H0&
+Public Const SD_SEND    As Long = &H1&
+Public Const SD_BOTH    As Long = &H2&
+Public Const INVALID_SOCKET = -1
+Public Const SOCKET_ERROR = -1
+Public Const SOCK_STREAM = 1
+Public Const SOCK_DGRAM = 2
+Public Const MAXGETHOSTSTRUCT = 1024
+Public Const AF_INET = 2
+Public Const PF_INET = 2
+
+Type LingerType
+
+    l_onoff As Integer
+    l_linger As Integer
+
+End Type
+
+' Windows Sockets definitions of regular Microsoft C error constants
+Public Const WSAEINTR = 10004
+Public Const WSAEBADF = 10009
+Public Const WSAEACCES = 10013
+Public Const WSAEFAULT = 10014
+Public Const WSAEINVAL = 10022
+Public Const WSAEMFILE = 10024
+
+' Windows Sockets definitions of regular Berkeley error constants
+Public Const WSAEWOULDBLOCK = 10035
+Public Const WSAEINPROGRESS = 10036
+Public Const WSAEALREADY = 10037
+Public Const WSAENOTSOCK = 10038
+Public Const WSAEDESTADDRREQ = 10039
+Public Const WSAEMSGSIZE = 10040
+Public Const WSAEPROTOTYPE = 10041
+Public Const WSAENOPROTOOPT = 10042
+Public Const WSAEPROTONOSUPPORT = 10043
+Public Const WSAESOCKTNOSUPPORT = 10044
+Public Const WSAEOPNOTSUPP = 10045
+Public Const WSAEPFNOSUPPORT = 10046
+Public Const WSAEAFNOSUPPORT = 10047
+Public Const WSAEADDRINUSE = 10048
+Public Const WSAEADDRNOTAVAIL = 10049
+Public Const WSAENETDOWN = 10050
+Public Const WSAENETUNREACH = 10051
+Public Const WSAENETRESET = 10052
+Public Const WSAECONNABORTED = 10053
+Public Const WSAECONNRESET = 10054
+Public Const WSAENOBUFS = 10055
+Public Const WSAEISCONN = 10056
+Public Const WSAENOTCONN = 10057
+Public Const WSAESHUTDOWN = 10058
+Public Const WSAETOOMANYREFS = 10059
+Public Const WSAETIMEDOUT = 10060
+Public Const WSAECONNREFUSED = 10061
+Public Const WSAELOOP = 10062
+Public Const WSAENAMETOOLONG = 10063
+Public Const WSAEHOSTDOWN = 10064
+Public Const WSAEHOSTUNREACH = 10065
+Public Const WSAENOTEMPTY = 10066
+Public Const WSAEPROCLIM = 10067
+Public Const WSAEUSERS = 10068
+Public Const WSAEDQUOT = 10069
+Public Const WSAESTALE = 10070
+Public Const WSAEREMOTE = 10071
+
+' Extended Windows Sockets error constant definitions
+Public Const WSASYSNOTREADY = 10091
+Public Const WSAVERNOTSUPPORTED = 10092
+Public Const WSANOTINITIALISED = 10093
+Public Const WSAHOST_NOT_FOUND = 11001
+Public Const WSATRY_AGAIN = 11002
+Public Const WSANO_RECOVERY = 11003
+Public Const WSANO_DATA = 11004
+Public Const WSANO_ADDRESS = 11004
+
+'---ioctl Constants
+Public Const FIONREAD = &H8004667F
+
+Public Const FIONBIO = &H8004667E
+
+Public Const FIOASYNC = &H8004667D
+
+'---Windows System Functions
+Public Declare Function PostMessage Lib "user32" Alias "PostMessageA" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal wParam As Long, ByVal lParam As Long) As Long
+Public Declare Sub MemCopy Lib "kernel32" Alias "RtlMoveMemory" (Dest As Any, Src As Any, ByVal cb&)
+Public Declare Function lstrlen Lib "kernel32" Alias "lstrlenA" (ByVal lpString As Any) As Long
+
+'---async notification constants
+Public Const SOL_SOCKET = &HFFFF&
+Public Const SO_LINGER = &H80&
+Public Const SO_RCVBUFFER = &H1002&             ' Agregado por Maraxus
+Public Const SO_SNDBUFFER = &H1001&              ' Agregado por Maraxus
+Public Const SO_CONDITIONAL_ACCEPT = &H3002&    ' Agregado por Maraxus
+Public Const FD_READ = &H1&
+Public Const FD_WRITE = &H2&
+Public Const FD_OOB = &H4&
+Public Const FD_ACCEPT = &H8&
+Public Const FD_CONNECT = &H10&
+Public Const FD_CLOSE = &H20&
+
+'---SOCKET FUNCTIONS
+Public Declare Function accept Lib "ws2_32.dll" (ByVal S As Long, addr As sockaddr, AddrLen As Long) As Long
+Public Declare Function bind Lib "ws2_32.dll" (ByVal S As Long, addr As sockaddr, ByVal namelen As Long) As Long
+Public Declare Function apiclosesocket Lib "ws2_32.dll" Alias "closesocket" (ByVal S As Long) As Long
+Public Declare Function connect Lib "ws2_32.dll" (ByVal S As Long, addr As sockaddr, ByVal namelen As Long) As Long
+Public Declare Function ioctlsocket Lib "ws2_32.dll" (ByVal S As Long, ByVal Cmd As Long, argp As Long) As Long
+Public Declare Function getpeername Lib "ws2_32.dll" (ByVal S As Long, sName As sockaddr, namelen As Long) As Long
+Public Declare Function getsockname Lib "ws2_32.dll" (ByVal S As Long, sName As sockaddr, namelen As Long) As Long
+Public Declare Function getsockopt Lib "ws2_32.dll" (ByVal S As Long, ByVal level As Long, ByVal optname As Long, optval As Any, optlen As Long) As Long
+Public Declare Function htonl Lib "ws2_32.dll" (ByVal hostlong As Long) As Long
+Public Declare Function htons Lib "ws2_32.dll" (ByVal hostshort As Long) As Integer
+Public Declare Function inet_addr Lib "ws2_32.dll" (ByVal cp As String) As Long
+Public Declare Function inet_ntoa Lib "ws2_32.dll" (ByVal inn As Long) As Long
+
+Public Declare Function listen Lib "ws2_32.dll" (ByVal S As Long, ByVal backlog As Long) As Long
+Public Declare Function ntohl Lib "ws2_32.dll" (ByVal netlong As Long) As Long
+Public Declare Function ntohs Lib "ws2_32.dll" (ByVal netshort As Long) As Integer
+Public Declare Function recv Lib "ws2_32.dll" (ByVal S As Long, ByRef buf As Any, ByVal buflen As Long, ByVal flags As Long) As Long
+Public Declare Function recvfrom Lib "ws2_32.dll" (ByVal S As Long, buf As Any, ByVal buflen As Long, ByVal flags As Long, from As sockaddr, fromlen As Long) As Long
+Public Declare Function ws_select Lib "ws2_32.dll" Alias "select" (ByVal nfds As Long, readfds As fd_set, writefds As fd_set, exceptfds As fd_set, timeout As timeval) As Long
+Public Declare Function send Lib "ws2_32.dll" (ByVal S As Long, buf As Any, ByVal buflen As Long, ByVal flags As Long) As Long
+Public Declare Function sendto Lib "ws2_32.dll" (ByVal S As Long, buf As Any, ByVal buflen As Long, ByVal flags As Long, to_addr As sockaddr, ByVal tolen As Long) As Long
+Public Declare Function setsockopt Lib "ws2_32.dll" (ByVal S As Long, ByVal level As Long, ByVal optname As Long, optval As Any, ByVal optlen As Long) As Long
+Public Declare Function ShutDown Lib "ws2_32.dll" Alias "shutdown" (ByVal S As Long, ByVal how As Long) As Long
+Public Declare Function Socket Lib "ws2_32.dll" Alias "socket" (ByVal af As Long, ByVal s_type As Long, ByVal Protocol As Long) As Long
+
+'---DATABASE FUNCTIONS
+Public Declare Function gethostbyaddr Lib "ws2_32.dll" (addr As Long, ByVal addr_len As Long, ByVal addr_type As Long) As Long
+Public Declare Function gethostbyname Lib "ws2_32.dll" (ByVal host_name As String) As Long
+Public Declare Function gethostname Lib "ws2_32.dll" (ByVal host_name As String, ByVal namelen As Long) As Long
+Public Declare Function getservbyport Lib "ws2_32.dll" (ByVal Port As Long, ByVal proto As String) As Long
+Public Declare Function getservbyname Lib "ws2_32.dll" (ByVal serv_name As String, ByVal proto As String) As Long
+Public Declare Function getprotobynumber Lib "ws2_32.dll" (ByVal proto As Long) As Long
+Public Declare Function getprotobyname Lib "ws2_32.dll" (ByVal proto_name As String) As Long
+
+'---WINDOWS EXTENSIONS
+Public Declare Function WSAStartup Lib "ws2_32.dll" (ByVal wVR As Long, lpWSAD As WSADataType) As Long
+Public Declare Function WSACleanup Lib "ws2_32.dll" () As Long
+Public Declare Sub WSASetLastError Lib "ws2_32.dll" (ByVal iError As Long)
+Public Declare Function WSAGetLastError Lib "ws2_32.dll" () As Long
+Public Declare Function WSAIsBlocking Lib "ws2_32.dll" () As Long
+Public Declare Function WSAUnhookBlockingHook Lib "ws2_32.dll" () As Long
+Public Declare Function WSASetBlockingHook Lib "ws2_32.dll" (ByVal lpBlockFunc As Long) As Long
+Public Declare Function WSACancelBlockingCall Lib "ws2_32.dll" () As Long
+Public Declare Function WSAAsyncGetServByName Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal serv_name As String, ByVal proto As String, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSAAsyncGetServByPort Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal Port As Long, ByVal proto As String, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSAAsyncGetProtoByName Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal proto_name As String, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSAAsyncGetProtoByNumber Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal Number As Long, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSAAsyncGetHostByName Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, ByVal host_name As String, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSAAsyncGetHostByAddr Lib "ws2_32.dll" (ByVal hWnd As Long, ByVal wMsg As Long, addr As Long, ByVal addr_len As Long, ByVal addr_type As Long, buf As Any, ByVal buflen As Long) As Long
+Public Declare Function WSACancelAsyncRequest Lib "ws2_32.dll" (ByVal hAsyncTaskHandle As Long) As Long
+Public Declare Function WSAAsyncSelect Lib "ws2_32.dll" (ByVal S As Long, ByVal hWnd As Long, ByVal wMsg As Long, ByVal lEvent As Long) As Long
+Public Declare Function WSARecvEx Lib "ws2_32.dll" (ByVal S As Long, buf As Any, ByVal buflen As Long, ByVal flags As Long) As Long
+
+'Agregado por Maraxus
+Declare Function WSAAccept Lib "ws2_32.dll" (ByVal S As Long, pSockAddr As sockaddr, AddrLen As Long, ByVal lpfnCondition As Long, ByVal dwCallbackData As Long) As Long
+
+Public Const SOMAXCONN As Long = &H7FFFFFFF            ' Agregado por Maraxus
+
+'SOME STUFF I ADDED
+Public MySocket%
+
+Public SockReadBuffer$
+
+Public Const WSA_NoName = "Unknown"
+
+Public WSAStartedUp As Boolean     'Flag to keep track of whether winsock WSAStartup wascalled
 
 Public Function WSAGetAsyncBufLen(ByVal lParam As Long) As Long
 
@@ -899,7 +363,6 @@ End Function
 
 Public Function WSAGetAsyncError(ByVal lParam As Long) As Integer
     WSAGetAsyncError = (lParam And &HFFFF0000) \ &H10000
-
 End Function
 
 Public Function AddrToIP(ByVal AddrOrIP$) As String
@@ -915,54 +378,54 @@ Public Function AddrToIP(ByVal AddrOrIP$) As String
 End Function
 
 'this function should work on 16 and 32 bit systems
-#If Win16 Then
-    Function ConnectSock(ByVal Host$, _
-                         ByVal Port%, _
-                         retIpPort$, _
-                         ByVal HWndToMsg%, _
-                         ByVal Async%) As Integer
+Function ConnectSock(ByVal Host$, ByVal Port&, retIpPort$, ByVal HWndToMsg&, ByVal Async%) As Long
 
-        Dim S%, SelectOps%, dummy%
+    Dim S&, SelectOps&, dummy&
 
-    #ElseIf Win32 Then
-        Function ConnectSock(ByVal Host$, ByVal Port&, retIpPort$, ByVal HWndToMsg&, ByVal Async%) As Long
+    Dim sockin As sockaddr
 
-            Dim S&, SelectOps&, dummy&
+    SockReadBuffer$ = vbNullString
+    sockin = saZero
+    sockin.sin_family = AF_INET
+    sockin.sin_port = htons(Port)
 
-        #End If
+    If sockin.sin_port = INVALID_SOCKET Then
+        ConnectSock = INVALID_SOCKET
+        Exit Function
 
-        Dim sockin As sockaddr
+    End If
 
-        SockReadBuffer$ = vbNullString
-        sockin = saZero
-        sockin.sin_family = AF_INET
-        sockin.sin_port = htons(Port)
+    sockin.sin_addr = GetHostByNameAlias(Host$)
 
-        If sockin.sin_port = INVALID_SOCKET Then
-            ConnectSock = INVALID_SOCKET
-            Exit Function
+    If sockin.sin_addr = INADDR_NONE Then
+        ConnectSock = INVALID_SOCKET
+        Exit Function
 
-        End If
+    End If
 
-        sockin.sin_addr = GetHostByNameAlias(Host$)
+    retIpPort$ = GetAscIP$(sockin.sin_addr) & ":" & ntohs(sockin.sin_port)
 
-        If sockin.sin_addr = INADDR_NONE Then
-            ConnectSock = INVALID_SOCKET
-            Exit Function
+    S = Socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)
 
-        End If
+    If S < 0 Then
+        ConnectSock = INVALID_SOCKET
+        Exit Function
 
-        retIpPort$ = GetAscIP$(sockin.sin_addr) & ":" & ntohs(sockin.sin_port)
+    End If
 
-        S = Socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)
-
-        If S < 0 Then
-            ConnectSock = INVALID_SOCKET
-            Exit Function
+    If SetSockLinger(S, 1, 0) = SOCKET_ERROR Then
+        If S > 0 Then
+            dummy = apiclosesocket(S)
 
         End If
 
-        If SetSockLinger(S, 1, 0) = SOCKET_ERROR Then
+        ConnectSock = INVALID_SOCKET
+        Exit Function
+
+    End If
+
+    If Not Async Then
+        If Not connect(S, sockin, sockaddr_size) = 0 Then
             If S > 0 Then
                 dummy = apiclosesocket(S)
 
@@ -973,35 +436,7 @@ End Function
 
         End If
 
-        If Not Async Then
-            If Not connect(S, sockin, sockaddr_size) = 0 Then
-                If S > 0 Then
-                    dummy = apiclosesocket(S)
-
-                End If
-
-                ConnectSock = INVALID_SOCKET
-                Exit Function
-
-            End If
-
-            If HWndToMsg <> 0 Then
-                SelectOps = FD_READ Or FD_WRITE Or FD_CONNECT Or FD_CLOSE
-
-                If WSAAsyncSelect(S, HWndToMsg, ByVal 1025, ByVal SelectOps) Then
-                    If S > 0 Then
-                        dummy = apiclosesocket(S)
-
-                    End If
-
-                    ConnectSock = INVALID_SOCKET
-                    Exit Function
-
-                End If
-
-            End If
-
-        Else
+        If HWndToMsg <> 0 Then
             SelectOps = FD_READ Or FD_WRITE Or FD_CONNECT Or FD_CLOSE
 
             If WSAAsyncSelect(S, HWndToMsg, ByVal 1025, ByVal SelectOps) Then
@@ -1015,51 +450,63 @@ End Function
 
             End If
 
-            If connect(S, sockin, sockaddr_size) <> -1 Then
-                If S > 0 Then
-                    dummy = apiclosesocket(S)
+        End If
 
-                End If
+    Else
+        SelectOps = FD_READ Or FD_WRITE Or FD_CONNECT Or FD_CLOSE
 
-                ConnectSock = INVALID_SOCKET
-                Exit Function
+        If WSAAsyncSelect(S, HWndToMsg, ByVal 1025, ByVal SelectOps) Then
+            If S > 0 Then
+                dummy = apiclosesocket(S)
 
             End If
 
+            ConnectSock = INVALID_SOCKET
+            Exit Function
+
         End If
 
-        ConnectSock = S
+        If connect(S, sockin, sockaddr_size) <> -1 Then
+            If S > 0 Then
+                dummy = apiclosesocket(S)
 
-    End Function
+            End If
 
-#If Win32 Then
-    Public Function SetSockLinger(ByVal SockNum&, ByVal OnOff%, ByVal LingerTime%) As Long
-    #Else
-        Public Function SetSockLinger(ByVal SockNum%, ByVal OnOff%, ByVal LingerTime%) As Integer
-        #End If
+            ConnectSock = INVALID_SOCKET
+            Exit Function
 
-        Dim Linger As LingerType
+        End If
 
-        Linger.l_onoff = OnOff
-        Linger.l_linger = LingerTime
+    End If
 
-        If setsockopt(SockNum, SOL_SOCKET, SO_LINGER, Linger, 4) Then
-            Debug.Print "Error setting linger info: " & WSAGetLastError()
+    ConnectSock = S
+
+End Function
+
+Public Function SetSockLinger(ByVal SockNum&, ByVal OnOff%, ByVal LingerTime%) As Long
+
+    Dim Linger As LingerType
+
+    Linger.l_onoff = OnOff
+    Linger.l_linger = LingerTime
+
+    If setsockopt(SockNum, SOL_SOCKET, SO_LINGER, Linger, 4) Then
+        Debug.Print "Error setting linger info: " & WSAGetLastError()
+        SetSockLinger = SOCKET_ERROR
+    Else
+
+        If getsockopt(SockNum, SOL_SOCKET, SO_LINGER, Linger, 4) Then
+            Debug.Print "Error getting linger info: " & WSAGetLastError()
             SetSockLinger = SOCKET_ERROR
         Else
-
-            If getsockopt(SockNum, SOL_SOCKET, SO_LINGER, Linger, 4) Then
-                Debug.Print "Error getting linger info: " & WSAGetLastError()
-                SetSockLinger = SOCKET_ERROR
-            Else
-                Debug.Print "Linger is on if nonzero: "; Linger.l_onoff
-                Debug.Print "Linger time if linger is on: "; Linger.l_linger
-
-            End If
+            Debug.Print "Linger is on if nonzero: "; Linger.l_onoff
+            Debug.Print "Linger time if linger is on: "; Linger.l_linger
 
         End If
 
-    End Function
+    End If
+
+End Function
 
 Sub EndWinsock()
 
@@ -1067,7 +514,6 @@ Sub EndWinsock()
 
     If WSAIsBlocking() Then
         ret = WSACancelBlockingCall()
-
     End If
 
     ret = WSACleanup()
@@ -1076,18 +522,9 @@ Sub EndWinsock()
 End Sub
 
 Public Function GetAscIP(ByVal inn As Long) As String
-    #If Win32 Then
 
-        Dim nStr&
-
-    #Else
-
-        Dim nStr%
-
-    #End If
-
+    Dim nStr&
     Dim lpStr&
-
     Dim retString$
 
     retString = String(32, 0)
@@ -1100,6 +537,7 @@ Public Function GetAscIP(ByVal inn As Long) As String
         MemCopy ByVal retString, ByVal lpStr, nStr
         retString = Left$(retString, nStr)
         GetAscIP = retString
+    
     Else
         GetAscIP = "255.255.255.255"
 
@@ -1183,154 +621,117 @@ Public Function GetLocalHostName() As String
 
 End Function
 
-#If Win16 Then
-    Public Function GetPeerAddress(ByVal S%) As String
+Public Function GetPeerAddress(ByVal S&) As String
 
-        Dim AddrLen%
+    Dim AddrLen&
 
-    #ElseIf Win32 Then
-        Public Function GetPeerAddress(ByVal S&) As String
+    Dim sa As sockaddr
 
-            Dim AddrLen&
+    AddrLen = sockaddr_size
 
-        #End If
+    If getpeername(S, sa, AddrLen) Then
+        GetPeerAddress = vbNullString
+    Else
+        GetPeerAddress = SockAddressToString(sa)
 
-        Dim sa As sockaddr
+    End If
 
-        AddrLen = sockaddr_size
+End Function
 
-        If getpeername(S, sa, AddrLen) Then
-            GetPeerAddress = vbNullString
+Public Function GetPortFromString(ByVal PortStr$) As Long
+
+    'sometimes users provide ports outside the range of a VB
+    'integer, so this function returns an integer for a string
+    'just to keep an error from happening, it converts the
+    'number to a negative if needed
+    If val(PortStr$) > 32767 Then
+        GetPortFromString = CInt(val(PortStr$) - &H10000)
+    Else
+        GetPortFromString = val(PortStr$)
+
+    End If
+
+    If Err Then GetPortFromString = 0
+
+End Function
+
+Function GetProtocolByName(ByVal Protocol$) As Long
+
+    Dim tmpShort&
+
+    Dim ppe&
+
+    Dim peDestProt As protoent
+
+    ppe = getprotobyname(Protocol)
+
+    If ppe Then
+        MemCopy peDestProt, ByVal ppe, protoent_size
+        GetProtocolByName = peDestProt.p_proto
+    Else
+        tmpShort = val(Protocol)
+
+        If tmpShort Then
+            GetProtocolByName = htons(tmpShort)
         Else
-            GetPeerAddress = SockAddressToString(sa)
+            GetProtocolByName = SOCKET_ERROR
 
         End If
 
-    End Function
+    End If
 
-#If Win16 Then
-    Public Function GetPortFromString(ByVal PortStr$) As Integer
-    #ElseIf Win32 Then
-        Public Function GetPortFromString(ByVal PortStr$) As Long
-        #End If
+End Function
 
-        'sometimes users provide ports outside the range of a VB
-        'integer, so this function returns an integer for a string
-        'just to keep an error from happening, it converts the
-        'number to a negative if needed
-        If val(PortStr$) > 32767 Then
-            GetPortFromString = CInt(val(PortStr$) - &H10000)
+Function GetServiceByName(ByVal service$, ByVal Protocol$) As Long
+
+    Dim Serv&
+
+    Dim pse&
+
+    Dim seDestServ As servent
+
+    pse = getservbyname(service, Protocol)
+
+    If pse Then
+        MemCopy seDestServ, ByVal pse, servent_size
+        GetServiceByName = seDestServ.s_port
+    Else
+        Serv = val(service)
+
+        If Serv Then
+            GetServiceByName = htons(Serv)
         Else
-            GetPortFromString = val(PortStr$)
+            GetServiceByName = INVALID_SOCKET
 
         End If
 
-        If Err Then GetPortFromString = 0
+    End If
 
-    End Function
-
-#If Win16 Then
-    Function GetProtocolByName(ByVal Protocol$) As Integer
-
-        Dim tmpShort%
-
-    #ElseIf Win32 Then
-        Function GetProtocolByName(ByVal Protocol$) As Long
-
-            Dim tmpShort&
-
-        #End If
-
-        Dim ppe&
-
-        Dim peDestProt As protoent
-
-        ppe = getprotobyname(Protocol)
-
-        If ppe Then
-            MemCopy peDestProt, ByVal ppe, protoent_size
-            GetProtocolByName = peDestProt.p_proto
-        Else
-            tmpShort = val(Protocol)
-
-            If tmpShort Then
-                GetProtocolByName = htons(tmpShort)
-            Else
-                GetProtocolByName = SOCKET_ERROR
-
-            End If
-
-        End If
-
-    End Function
-
-#If Win16 Then
-    Function GetServiceByName(ByVal service$, ByVal Protocol$) As Integer
-
-        Dim Serv%
-
-    #ElseIf Win32 Then
-        Function GetServiceByName(ByVal service$, ByVal Protocol$) As Long
-
-            Dim Serv&
-
-        #End If
-
-        Dim pse&
-
-        Dim seDestServ As servent
-
-        pse = getservbyname(service, Protocol)
-
-        If pse Then
-            MemCopy seDestServ, ByVal pse, servent_size
-            GetServiceByName = seDestServ.s_port
-        Else
-            Serv = val(service)
-
-            If Serv Then
-                GetServiceByName = htons(Serv)
-            Else
-                GetServiceByName = INVALID_SOCKET
-
-            End If
-
-        End If
-
-    End Function
+End Function
 
 'this function DOES work on 16 and 32 bit systems
-#If Win16 Then
-    Function GetSockAddress(ByVal S%) As String
 
-        Dim AddrLen%
+Function GetSockAddress(ByVal S&) As String
 
-        Dim ret%
+    Dim AddrLen&
 
-    #ElseIf Win32 Then
-        Function GetSockAddress(ByVal S&) As String
+    Dim ret&
 
-            Dim AddrLen&
+    Dim sa As sockaddr
 
-            Dim ret&
+    Dim szRet$
 
-        #End If
+    szRet = String(32, 0)
+    AddrLen = sockaddr_size
 
-        Dim sa As sockaddr
+    If getsockname(S, sa, AddrLen) Then
+        GetSockAddress = vbNullString
+    Else
+        GetSockAddress = SockAddressToString(sa)
 
-        Dim szRet$
+    End If
 
-        szRet = String(32, 0)
-        AddrLen = sockaddr_size
-
-        If getsockname(S, sa, AddrLen) Then
-            GetSockAddress = vbNullString
-        Else
-            GetSockAddress = SockAddressToString(sa)
-
-        End If
-
-    End Function
+End Function
 
 'this function should work on 16 and 32 bit systems
 Function GetWSAErrorString(ByVal errnum&) As String
@@ -1518,15 +919,7 @@ Function IrcGetAscIp(ByVal IPL$) As String
 
     Dim lpStr&
 
-    #If Win16 Then
-
-        Dim nStr%
-
-    #ElseIf Win32 Then
-
-        Dim nStr&
-
-    #End If
+    Dim nStr&
 
     Dim retString$
 
@@ -1598,153 +991,126 @@ IrcGetLongIpError:
 End Function
 
 'this function should work on 16 and 32 bit systems
-#If Win16 Then
-    Public Function ListenForConnect(ByVal Port%, _
-                                     ByVal HWndToMsg%, _
-                                     ByVal Enlazar As String) As Integer
 
-        Dim S%, dummy%
+Public Function ListenForConnect(ByVal Port&, ByVal HWndToMsg&, ByVal Enlazar As String) As Long
 
-        Dim SelectOps%
+    Dim S&, dummy&
 
-    #ElseIf Win32 Then
-        Public Function ListenForConnect(ByVal Port&, ByVal HWndToMsg&, ByVal Enlazar As String) As Long
+    Dim SelectOps&
 
-            Dim S&, dummy&
+    Dim sockin As sockaddr
 
-            Dim SelectOps&
+    sockin = saZero     'zero out the structure
+    sockin.sin_family = AF_INET
+    sockin.sin_port = htons(Port)
 
-        #End If
+    If sockin.sin_port = INVALID_SOCKET Then
+        ListenForConnect = INVALID_SOCKET
+        Exit Function
 
-        Dim sockin As sockaddr
+    End If
 
-        sockin = saZero     'zero out the structure
-        sockin.sin_family = AF_INET
-        sockin.sin_port = htons(Port)
+    If LenB(Enlazar) = 0 Then
+        sockin.sin_addr = htonl(INADDR_ANY)
+    Else
+        sockin.sin_addr = inet_addr(Enlazar)
 
-        If sockin.sin_port = INVALID_SOCKET Then
-            ListenForConnect = INVALID_SOCKET
-            Exit Function
+    End If
 
-        End If
+    If sockin.sin_addr = INADDR_NONE Then
+        ListenForConnect = INVALID_SOCKET
+        Exit Function
 
-        If LenB(Enlazar) = 0 Then
-            sockin.sin_addr = htonl(INADDR_ANY)
-        Else
-            sockin.sin_addr = inet_addr(Enlazar)
+    End If
 
-        End If
+    S = Socket(PF_INET, SOCK_STREAM, 0)
 
-        If sockin.sin_addr = INADDR_NONE Then
-            ListenForConnect = INVALID_SOCKET
-            Exit Function
+    If S < 0 Then
+        ListenForConnect = INVALID_SOCKET
+        Exit Function
 
-        End If
-
-        S = Socket(PF_INET, SOCK_STREAM, 0)
-
-        If S < 0 Then
-            ListenForConnect = INVALID_SOCKET
-            Exit Function
-
-        End If
+    End If
     
-        'Agregado por Maraxus
-        'If setsockopt(S, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, True, 2) Then
-        '    LogApiSock ("Error seteando conditional accept")
-        '    Debug.Print "Error seteando conditional accept"
-        'Else
-        '    LogApiSock ("Conditional accept seteado")
-        '    Debug.Print "Conditional accept seteado ^^"
-        'End If
+    'Agregado por Maraxus
+    'If setsockopt(S, SOL_SOCKET, SO_CONDITIONAL_ACCEPT, True, 2) Then
+    '    LogApiSock ("Error seteando conditional accept")
+    '    Debug.Print "Error seteando conditional accept"
+    'Else
+    '    LogApiSock ("Conditional accept seteado")
+    '    Debug.Print "Conditional accept seteado ^^"
+    'End If
     
-        If bind(S, sockin, sockaddr_size) Then
-            If S > 0 Then
-                dummy = apiclosesocket(S)
-
-            End If
-
-            ListenForConnect = INVALID_SOCKET
-            Exit Function
+    If bind(S, sockin, sockaddr_size) Then
+        If S > 0 Then
+            dummy = apiclosesocket(S)
 
         End If
 
-        '    SelectOps = FD_READ Or FD_WRITE Or FD_CLOSE Or FD_ACCEPT
-        SelectOps = FD_READ Or FD_CLOSE Or FD_ACCEPT
+        ListenForConnect = INVALID_SOCKET
+        Exit Function
 
-        If WSAAsyncSelect(S, HWndToMsg, ByVal 1025, ByVal SelectOps) Then
-            If S > 0 Then
-                dummy = apiclosesocket(S)
+    End If
 
-            End If
+    '    SelectOps = FD_READ Or FD_WRITE Or FD_CLOSE Or FD_ACCEPT
+    SelectOps = FD_READ Or FD_CLOSE Or FD_ACCEPT
 
-            ListenForConnect = SOCKET_ERROR
-            Exit Function
+    If WSAAsyncSelect(S, HWndToMsg, ByVal 1025, ByVal SelectOps) Then
+        If S > 0 Then
+            dummy = apiclosesocket(S)
 
         End If
+
+        ListenForConnect = SOCKET_ERROR
+        Exit Function
+
+    End If
     
-        'If listen(s, 5) Then
-        If listen(S, SOMAXCONN) Then
-            If S > 0 Then
-                dummy = apiclosesocket(S)
-
-            End If
-
-            ListenForConnect = INVALID_SOCKET
-            Exit Function
+    'If listen(s, 5) Then
+    If listen(S, SOMAXCONN) Then
+        If S > 0 Then
+            dummy = apiclosesocket(S)
 
         End If
 
-        ListenForConnect = S
+        ListenForConnect = INVALID_SOCKET
+        Exit Function
 
-    End Function
+    End If
 
-'this function should work on 16 and 32 bit systems
-#If Win16 Then
-    Public Function kSendData(ByVal S%, vMessage As Variant) As Integer
-    #ElseIf Win32 Then
-        Public Function kSendData(ByVal S&, vMessage As Variant) As Long
-        #End If
+    ListenForConnect = S
 
-        Dim TheMsg() As Byte, sTemp$
+End Function
 
-        TheMsg = vbNullString
+Public Function kSendData(ByVal S&, vMessage As Variant) As Long
 
-        Select Case VarType(vMessage)
+    Dim TheMsg() As Byte, sTemp$
 
-            Case 8209   'byte array
-                sTemp = vMessage
-                TheMsg = sTemp
+    TheMsg = vbNullString
 
-            Case 8      'string, if we recieve a string, its assumed we are linemode
-                #If Win32 Then
-                    sTemp = StrConv(vMessage, vbFromUnicode)
-                #Else
-                    sTemp = vMessage
-                #End If
+    Select Case VarType(vMessage)
 
-            Case Else
-                sTemp = CStr(vMessage)
-                #If Win32 Then
-                    sTemp = StrConv(vMessage, vbFromUnicode)
-                #Else
-                    sTemp = vMessage
-                #End If
+        Case 8209   'byte array
+            sTemp = vMessage
+            TheMsg = sTemp
 
-        End Select
+        Case 8      'string, if we recieve a string, its assumed we are linemode
+            sTemp = StrConv(vMessage, vbFromUnicode)
 
-        TheMsg = sTemp
+        Case Else
+            sTemp = StrConv(CStr(vMessage), vbFromUnicode)
 
-        If UBound(TheMsg) > -1 Then
-            kSendData = send(S, TheMsg(0), UBound(TheMsg) + 1, 0)
+    End Select
 
-        End If
+    TheMsg = sTemp
 
-    End Function
+    If UBound(TheMsg) > -1 Then
+        kSendData = send(S, TheMsg(0), UBound(TheMsg) + 1, 0)
+    End If
+
+End Function
 
 Public Function SockAddressToString(sa As sockaddr) As String
     SockAddressToString = GetAscIP(sa.sin_addr) & ":" & ntohs(sa.sin_port)
-
 End Function
 
 Public Function StartWinsock(sDescription As String) As Boolean
@@ -1775,7 +1141,4 @@ End Function
 
 Public Function WSAMakeSelectReply(TheEvent%, TheError%) As Long
     WSAMakeSelectReply = (TheError * &H10000) + (TheEvent And &HFFFF&)
-
 End Function
-
-#End If

--- a/SERVER.VBP
+++ b/SERVER.VBP
@@ -99,7 +99,7 @@ VersionComments="http://www.ArgentumOnline.org"
 VersionCompanyName="http://www.ArgentumOnline.org"
 VersionLegalCopyright="Argentum Online is copyright of Pablo Ignacio Marquez"
 VersionProductName="Argentum Server"
-CondComp="UsarQueSocket = 1 : ConUpTime = 1"
+CondComp="ConUpTime = 1"
 CompilationType=0
 OptimizationType=0
 FavorPentiumPro(tm)=0


### PR DESCRIPTION
- Se eliminó el codigo relacionado con SocketWrench(UsarQueSocket = 0) y TCPServ(UsarQueSocket = 3)
- Se sacó el código relacionado con sistemas Win16 en `wsksock.bas`
- Se sacó UsarQueSocket.
- Ahora solo usamos Winsock2 API (ws2_32.dll)