### PR TITLE
EXP y ELU tienen el mismo tipo de dato, LONG

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1330,7 +1330,7 @@ Public Type UserStats
     MinAGU As Integer
         
     def As Integer
-    Exp As Double
+    Exp As Long
     ELV As Byte
     ELU As Long
     UserSkills(1 To NUMSKILLS) As Byte


### PR DESCRIPTION
Intento para arreglar este problema: https://github.com/ao-libre/ao-server/issues/409

Se me hace que ELU y EXP deben de ser el mismo tipo de dato.