### PR TITLE
Update Protocol.bas

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -3121,7 +3121,7 @@ Private Sub HandleWork(ByVal Userindex As Integer)
             Case Ocultarse
                 
                 ' Verifico si se peude ocultar en este mapa
-                If MapInfo(.Pos.Map).OcultarSinEfecto = 1 Then
+                If (MapInfo(.Pos.Map).OcultarSinEfecto = 1) or (MapInfo(.Pos.Map).InviSinEfecto = 1) Then
                     Call WriteConsoleMsg(Userindex, "Ocultarse no funciona aqui!", FontTypeNames.FONTTYPE_INFO)
                     Exit Sub
 


### PR DESCRIPTION
Arreglo 2

OcultarSinEfecto, se cambia ingame por un GM, hay que dejarlo y agregar tmb la otra condicion.

Un pequenio fix en el SV. Si un mapa no permite hacerce Invisible, tampoco permita Ocultarse. Por ejemplo, para usar en un mapa de agite, un Death, un Torneo, etc.

InviSinEfecto(0-valeInvi y 1-noValeInvi) es el valor que guarda un Mapa al hacerse en los Dats.