### PR TITLE
Corrección Index 'Gorro de Navidad'

### DIFF
--- a/Dat/ArmadurasHerrero.dat
+++ b/Dat/ArmadurasHerrero.dat
@@ -198,7 +198,7 @@ Index=1136
 Index=1141
 
 [Armadura66] ' Gorro de Navidad
-Index=1142
+Index=1143
 
 [Armadura67] ' Corona de Rey
 Index=1146


### PR DESCRIPTION
El correcto es el 1143. Gracias.