### PR TITLE
El worldsave avisa antes de 15 segundos que se hace, se saco los 5 minutos por que genera falla de seguridad al juego permitiendo llenar el buffer (MAX_ITEMS) en el tiempo restante

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -546,9 +546,9 @@ Sub DropObj(ByVal Userindex As Integer, _
 
                 End If
             
-                Call MakeObj(DropObj, Map, X, Y)
                 Call QuitarUserInvItem(Userindex, Slot, DropObj.Amount)
                 Call UpdateUserInv(False, Userindex, Slot)
+                Call MakeObj(DropObj, Map, X, Y)
             
                 If ObjData(DropObj.ObjIndex).OBJType = eOBJType.otBarcos Then
                     Call WriteConsoleMsg(Userindex, "ATENCION!! ACABAS DE TIRAR TU BARCA!", FontTypeNames.FONTTYPE_WARNING)

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -23784,7 +23784,7 @@ Public Sub HandleLimpiarMundo(ByVal Userindex As Integer)
     
     Call LogGM(UserList(Userindex).Name, "forzo la limpieza del mundo.")
     
-    tickLimpieza = 301
+    tickLimpieza = 16
     
 End Sub
 

--- a/Codigo/mLimpieza.bas
+++ b/Codigo/mLimpieza.bas
@@ -28,22 +28,20 @@ Public Sub AgregarObjetoLimpieza(Pos As WorldPos)
     'Alcanzamos los slots que permite almacenar?
     '//Reservamos 100 slots por si cuando empieza a limpiar el mundo, siguen tirando objetos.
     If UltimoSlotLimpieza = MAXITEMS - 100 Then
-        tickLimpieza = 301
+        tickLimpieza = 16
     End If
 
 End Sub
 
 Public Sub BorrarObjetosLimpieza()
-
-    UltimoSlotLimpieza = -1
-    
     Dim i As Long
 
     For i = 0 To MAXITEMS
 
         With ArrayLimpieza(i)
 
-            If (MapData(.Map, .X, .Y).trigger <> eTrigger.CASA Or MapData(.Map, .X, .Y).trigger <> eTrigger.BAJOTECHO) And _
+            If (MapData(.Map, .X, .Y).trigger <> eTrigger.CASA Or _ 
+                MapData(.Map, .X, .Y).trigger <> eTrigger.BAJOTECHO) And _
                 MapData(.Map, .X, .Y).Blocked <> 1 Then
                 
                 Call EraseObj(MapData(.Map, .X, .Y).ObjInfo.Amount, .Map, .X, .Y)
@@ -52,5 +50,7 @@ Public Sub BorrarObjetosLimpieza()
         End With
 
     Next i
+
+    UltimoSlotLimpieza = -1
 
 End Sub

--- a/Codigo/mMainLoop.bas
+++ b/Codigo/mMainLoop.bas
@@ -336,6 +336,15 @@ Public Sub PasarSegundo()
             Case 300
                 Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor> Limpieza del mundo en 5 Minuto. Atentos!!", FontTypeNames.FONTTYPE_SERVER))
 
+            Case 240
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor> Limpieza del mundo en 4 Minutos. Atentos!!", FontTypeNames.FONTTYPE_SERVER))
+
+            Case 180
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor> Limpieza del mundo en 3 Minutos. Atentos!!", FontTypeNames.FONTTYPE_SERVER))
+            
+            Case 120
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor> Limpieza del mundo en 2 Minutos. Atentos!!", FontTypeNames.FONTTYPE_SERVER))
+
             Case 60
                 Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor> Limpieza del mundo en 1 Minuto. Atentos!!", FontTypeNames.FONTTYPE_SERVER))
    


### PR DESCRIPTION
El worldsave avisa antes de 15 segundos que se hace, se saco los 5 minutos por que genera falla de seguridad al juego permitiendo llenar el buffer (MAX_ITEMS) en el tiempo restante, ahora ya
 no es tan simple hacerlo con objetos de valor, lo ultimo que se hace al tirar un objeto es crearlo en el piso lo primero es eliminarlo del inventario de usuario