### PR TITLE
Fix HappyHour: No daba experiencia extra

### DIFF
--- a/Server.ini
+++ b/Server.ini
@@ -195,10 +195,10 @@ Password=
 [HAPPYHOUR]
 Activado=1
 ## Formato: Hora-% (la hora es de 0 a 23hs) (el % es convertido x100, 1 el doble de exp)
-Dia1=20-1	## Lunes
-Dia2=20-1
-Dia3=20-1
-Dia4=19-1
-Dia5=19-1
-Dia6=19-1
-Dia7=18-1	## Domingo
+Dia1=18-1.5	## Domingo
+Dia2=20-1.5	## Lunes
+Dia3=20-1.5	## Martes
+Dia4=20-1.5	## Miercoles
+Dia5=19-1.5	## Jueves
+Dia6=19-2.0	## Viernes
+Dia7=19-2.0	## Sabado

--- a/Server.ini
+++ b/Server.ini
@@ -194,7 +194,7 @@ Password=
 
 [HAPPYHOUR]
 Activado=1
-## Formato: Hora-% (la hora es de 0 a 23hs) (el % es convertido x100, 1 el doble de exp)
+## Formato: Hora-Mult (La hora es de 0 a 23hs) (El multiplicador puede contener decimales)
 Dia1=18-1.5	## Domingo
 Dia2=20-1.5	## Lunes
 Dia3=20-1.5	## Martes


### PR DESCRIPTION
Todos los multiplicadores estaban puestos en 1. La HappyHour no daba experiencia extra.
También estaba mal asignado el día 1 al lunes, pero igual no cambiaba mucho.
Por favor, cambiar los valores por los que corresponda, yo sólo puse un ejemplo.