### PR TITLE
se agrega sub nombre al haber 2 NPC iguales

### DIFF
--- a/Dat/NPCs.dat
+++ b/Dat/NPCs.dat
@@ -7992,7 +7992,7 @@ Drop5=1002-5 'Cascos de Lobo
 ############################################
 
 [NPC602]
-Name=Piranha
+Name=Piranha de Oceano
 NpcType=0
 Head=0
 Heading=3


### PR DESCRIPTION
Al haber 2 npc con nombre piranha interfiria en la quest que pide matar lo ya mencionado